### PR TITLE
Feat/issue127 standardize status

### DIFF
--- a/contracts/raffle/src/instance/mod.rs
+++ b/contracts/raffle/src/instance/mod.rs
@@ -36,7 +36,7 @@ pub struct Contract;
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[contracttype]
 pub enum RaffleStatus {
-    Open = 0,
+    Active = 0,
     Drawing = 1,
     Finalized = 2,
     Cancelled = 3,
@@ -471,7 +471,7 @@ impl Contract {
             prize_amount: config.prize_amount,
             prizes: config.prizes.clone(),
             tickets_sold: 0,
-            status: RaffleStatus::Open,
+            status: RaffleStatus::Active,
             prize_deposited: false,
             winners: Vec::new(&env),
             claimed_winners: Vec::new(&env),
@@ -512,7 +512,7 @@ impl Contract {
         require_creator(&env)?;
         let mut raffle = read_raffle(&env)?;
 
-        if raffle.status != RaffleStatus::Open {
+        if raffle.status != RaffleStatus::Active {
             return Err(Error::InvalidStateTransition);
         }
         if raffle.prize_deposited {
@@ -561,8 +561,11 @@ impl Contract {
         let mut raffle = read_raffle(&env)?;
 
         // --- 1. CHECKS ---
-        if raffle.status != RaffleStatus::Open {
+        if raffle.status != RaffleStatus::Active {
             return Err(Error::RaffleInactive);
+        }
+        if !raffle.prize_deposited {
+            return Err(Error::InvalidStateTransition);
         }
         if raffle.end_time != 0 && env.ledger().timestamp() > raffle.end_time {
             return Err(Error::RaffleExpired);
@@ -608,7 +611,7 @@ impl Contract {
                 &env,
                 "status_changed",
                 RaffleStatusChanged {
-                    old_status: RaffleStatus::Open,
+                    old_status: RaffleStatus::Active,
                     new_status: RaffleStatus::Drawing,
                     timestamp,
                 },
@@ -668,7 +671,7 @@ impl Contract {
         require_creator(&env)?;
         let mut raffle = read_raffle(&env)?;
 
-        if raffle.status == RaffleStatus::Open {
+        if raffle.status == RaffleStatus::Active {
             if (raffle.end_time != 0 && env.ledger().timestamp() >= raffle.end_time)
                 || raffle.tickets_sold >= raffle.max_tickets
             {
@@ -677,7 +680,7 @@ impl Contract {
                     &env,
                     "status_changed",
                     RaffleStatusChanged {
-                        old_status: RaffleStatus::Open,
+                        old_status: RaffleStatus::Active,
                         new_status: RaffleStatus::Drawing,
                         timestamp: env.ledger().timestamp(),
                     },
@@ -861,7 +864,7 @@ impl Contract {
         }
 
         // Transition Active → Drawing if the raffle end conditions are satisfied
-        if raffle.status == RaffleStatus::Open {
+        if raffle.status == RaffleStatus::Active {
             let now = env.ledger().timestamp();
             let time_ended = raffle.end_time != 0 && now >= raffle.end_time;
             let tickets_full = raffle.tickets_sold >= raffle.max_tickets;
@@ -873,7 +876,7 @@ impl Contract {
                 &env,
                 "status_changed",
                 RaffleStatusChanged {
-                    old_status: RaffleStatus::Open,
+                    old_status: RaffleStatus::Active,
                     new_status: RaffleStatus::Drawing,
                     timestamp: now,
                 },

--- a/contracts/raffle/src/instance/test.rs
+++ b/contracts/raffle/src/instance/test.rs
@@ -703,7 +703,7 @@ fn test_creator_can_deposit_prize() {
 
     // Should succeed — creator auth is mocked
     client.deposit_prize();
-    assert_eq!(client.get_raffle().status, RaffleStatus::Open);
+    assert_eq!(client.get_raffle().status, RaffleStatus::Active);
 }
 
 /// require_creator: creator can finalize raffle
@@ -1092,7 +1092,7 @@ fn test_deposit_prize_cei_state_active_after_call() {
     client.deposit_prize();
 
     let raffle = client.get_raffle();
-    assert!(raffle.status == RaffleStatus::Open);
+    assert!(raffle.status == RaffleStatus::Active);
     assert!(raffle.prize_deposited);
 }
 


### PR DESCRIPTION
closes #127 

Changes Made
1. Standardized RaffleStatus Enum
Renamed Open to Active: The variant RaffleStatus::Open has been renamed to RaffleStatus::Active to align with the terminology used in logic checks and to fulfill the requirement for consistency.
Updated All References: Audited and updated every occurrence of RaffleStatus::Open in mod.rs, lib.rs, and test.rs.
2. Resolved Logic Inconsistencies
buy_tickets Fix: Updated the logic in buy_tickets to ensure it only proceeds if the raffle status is Active and the prize has been deposited. This resolves the reported inconsistency where tickets could be purchased before the raffle was fully "Active" (i.e., prize-backed).
finalize_raffle Audit: Verified that finalize_raffle correctly transitions a raffle from Active to Drawing only when the expiration or ticket-count conditions are met, ensuring state integrity.
3. Test Suite Stabilization
Fixed Failing Panic Tests: The rename and the addition of the prize_deposited check resolved several failing unit tests (e.g., test_invalid_state_transition_buy_before_deposit) that were previously passing incorrectly.
Updated Mocking: Ensured all test cases use the new Active variant, maintaining a passing build.
Verification Results
Status Consistency: All RaffleStatus variants are now used consistently across the codebase.
Test Results: Core raffle flow tests and status-transition tests (like test_basic_internal_raffle_flow) are passing.
Build: cargo check and cargo test verify the structural integrity of the changes.