### PR TITLE
fix: correct TicketCount removal to use buyer's Address

### DIFF
--- a/contracts/raffle/src/instance/mod.rs
+++ b/contracts/raffle/src/instance/mod.rs
@@ -2111,7 +2111,7 @@ impl Contract {
         for ticket in tickets_list.iter() {
             env.storage()
                 .persistent()
-                .remove(&DataKey::TicketCount(ticket.owner));
+                .remove(&DataKey::TicketCount(ticket.owner.clone()));
         }
         // Remove FinishTime
         env.storage().persistent().remove(&DataKey::FinishTime);


### PR DESCRIPTION
- Fixed type mismatch in wipe_storage where DataKey::TicketCount was called without cloning the Address
- Ensured consistency with read_ticket_count and write_ticket_count which both use Address.clone()
- Resolves #129: Core fix for type mismatches in ticket counting storage

Closes #129 