### PR TITLE
fix: index metadata_hash as topic in RaffleCreated event

### DIFF
--- a/contracts/raffle/src/events.rs
+++ b/contracts/raffle/src/events.rs
@@ -21,6 +21,7 @@ pub struct RaffleCreated {
     pub description: String,
     pub randomness_source: RandomnessSource,
     /// SHA-256 hash of the off-chain metadata (description, image, rules) on IPFS.
+    #[topic]
     pub metadata_hash: BytesN<32>,
 }
 


### PR DESCRIPTION
## Summary

- Adds `#[topic]` annotation to `metadata_hash` in the `RaffleCreated` event struct
- This makes the SHA-256 IPFS metadata hash an indexed Soroban event topic, allowing off-chain indexers to efficiently query raffles by their metadata hash without scanning all event data

Closes #185
Closes #191 
Closes #184 
Closes #194 

🤖 Generated with [Claude Code](https://claude.com/claude-code)