### PR TITLE
feat: add do_refund parameter to trigger_randomness_fallback to support raffle cancellation

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -32,6 +32,7 @@ pub const MIN_TICKET_PRICE: i128 = 10_000;
 #[contract]
 pub struct Contract;
 
+#[soroban_sdk::contracttype]
 #[derive(Clone)]
 pub struct Raffle {
     pub creator: Address,
@@ -59,6 +60,7 @@ pub struct Raffle {
     pub winner_ticket_id: Option<u32>,
 }
 
+#[soroban_sdk::contracttype]
 #[derive(Clone)]
 pub struct FairnessMetadata {
     pub seed: u64,
@@ -497,9 +499,9 @@ impl Contract {
         Ok(env.current_contract_address())
     }
 
-    pub fn trigger_randomness_fallback(env: Env, caller: Address) -> Result<(), Error> {
+    pub fn trigger_randomness_fallback(env: Env, caller: Address, do_refund: bool) -> Result<(), Error> {
         caller.require_auth();
-        let raffle = read_raffle(&env)?;
+        let mut raffle = read_raffle(&env)?;
 
         let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
         if caller != raffle.creator && caller != admin {
@@ -518,6 +520,20 @@ impl Contract {
         let request_ledger: u32 = env.storage().instance().get(&DataKey::RandomnessRequestLedger).unwrap_or(0);
         if env.ledger().sequence() < request_ledger + ORACLE_TIMEOUT_LEDGERS {
             return Err(Error::FallbackTooEarly);
+        }
+
+        if do_refund {
+            raffle.status = RaffleStatus::Cancelled;
+            write_raffle(&env, &raffle);
+
+            RaffleCancelled {
+                creator: raffle.creator.clone(),
+                reason: CancelReason::OracleTimeout,
+                tickets_sold: raffle.tickets_sold,
+                prize_refunded: raffle.prize_deposited,
+                timestamp: env.ledger().timestamp(),
+            }.publish(&env);
+            return Ok(());
         }
 
         let seed = build_internal_seed_u64(&env);


### PR DESCRIPTION
I've modified the trigger_randomness_fallback function in contracts/raffle-instance/src/lib.rs to include a new boolean parameter do_refund. This handles the oracle offline timeout exactly as requested:

Timeout Check: It continues to ensure the fallback is only triggered after ORACLE_TIMEOUT_LEDGERS have passed since the randomness was originally requested.
Refund (Cancel) Path: If do_refund is set to true, the contract transitions the raffle's status to Cancelled and emits a RaffleCancelled event with the reason set to CancelReason::OracleTimeout. Users and prize creators can then trigger the usual refund_ticket and refund_prize flows.
Internal PRNG Path: If do_refund is set to false, it behaves identically to its prior implementation, emitting a RandomnessFallbackTriggered event and immediately proceeding with an on-chain internal PRNG draw.


Close #165