### PR TITLE
refactor: update Raffle schema, enable rlib for instance crate, and correct winner drawing logic

### DIFF
--- a/contracts/raffle-instance/Cargo.toml
+++ b/contracts/raffle-instance/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -18,7 +18,7 @@ use self::randomness::{
 };
 
 use crate::events::{
-    DrawTriggered, PrizeClaimed, PrizeDeposited, PrizeRefunded, RaffleCancelled, RaffleCreated,
+    PrizeClaimed, PrizeDeposited, PrizeRefunded, RaffleCancelled, RaffleCreated,
     RaffleFinalized, RaffleStatusChanged, RandomnessReceived,
     RandomnessRequested, TicketPurchased,
     WinnerDrawn, RandomnessFallbackTriggered,
@@ -33,6 +33,7 @@ pub const MIN_TICKET_PRICE: i128 = 10_000;
 pub struct Contract;
 
 #[derive(Clone)]
+#[soroban_sdk::contracttype]
 pub struct Raffle {
     pub creator: Address,
     pub description: String,
@@ -56,10 +57,10 @@ pub struct Raffle {
     pub swap_router: Option<Address>,
     pub tikka_token: Option<Address>,
     pub finalized_at: Option<u64>,
-    pub winner_ticket_id: Option<u32>,
 }
 
 #[derive(Clone)]
+#[soroban_sdk::contracttype]
 pub struct FairnessMetadata {
     pub seed: u64,
     pub randomness_source: RandomnessSource,
@@ -271,7 +272,6 @@ impl Contract {
             swap_router: config.swap_router,
             tikka_token: config.tikka_token,
             finalized_at: None,
-            winner_ticket_id: None,
         };
         write_raffle(&env, &raffle);
         env.storage().instance().set(&DataKey::Factory, &factory);
@@ -301,7 +301,7 @@ impl Contract {
             return Err(Error::PrizeAlreadyDeposited);
         }
 
-        let old_status = raffle.status.clone();
+        let _old_status = raffle.status.clone();
         raffle.prize_deposited = true;
         write_raffle(&env, &raffle);
 
@@ -465,7 +465,7 @@ impl Contract {
         public_key: BytesN<32>,
         proof: BytesN<64>,
     ) -> Result<Address, Error> {
-        let mut raffle = read_raffle(&env)?;
+        let raffle = read_raffle(&env)?;
 
         let oracle = match &raffle.oracle_address {
             Some(addr) => {
@@ -543,7 +543,7 @@ impl Contract {
             return Err(Error::InvalidStatus);
         }
 
-        if tier_index as usize >= raffle.winners.len() {
+        if tier_index >= raffle.winners.len() {
             return Err(Error::InvalidParameters);
         }
 
@@ -612,7 +612,7 @@ impl Contract {
             return Err(Error::InvalidStatus);
         }
 
-        let old_status = raffle.status.clone();
+        let _old_status = raffle.status.clone();
         raffle.status = RaffleStatus::Cancelled;
         write_raffle(&env, &raffle);
 
@@ -694,7 +694,7 @@ impl Contract {
 
     pub fn get_fairness_data(env: Env) -> Result<FairnessData, Error> {
         let metadata: FairnessMetadata = env.storage().instance().get(&DataKey::RandomnessSeed).ok_or(Error::InvalidStatus)?;
-        let raffle = read_raffle(&env)?;
+        let _raffle = read_raffle(&env)?;
         
         let mut ticket_ids = Vec::new(&env);
         let count = get_ticket_count(&env);
@@ -773,7 +773,7 @@ fn do_finalize_with_seed(
 
         WinnerDrawn {
             winner,
-            ticket_id: winner_index,
+            ticket_id,
             tier_index: i,
             timestamp: env.ledger().timestamp(),
         }.publish(&env);

--- a/contracts/raffle/src/events.rs
+++ b/contracts/raffle/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, Address, BytesN, u128};
+use soroban_sdk::{contractevent, Address, BytesN};
 use raffle_shared::AdminOp;
 
 #[derive(Clone)]

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -360,6 +360,7 @@ impl RaffleFactory {
 
         #[cfg(test)]
         let raffle_address = {
+            use soroban_sdk::testutils::Address as _;
             let mut count: u32 = env.storage().persistent().get(&DataKey::RaffleInstancesCount).unwrap_or(0);
             count += 1;
             env.storage().persistent().set(&DataKey::RaffleInstancesCount, &count);
@@ -719,6 +720,7 @@ mod tests {
         let contract_id = env.register(RaffleFactory, ());
         let client = RaffleFactoryClient::new(env, &contract_id);
         client.init_factory(&admin, &wasm_hash, &0u32, &treasury);
+        env.mock_all_auths();
         client.set_creation_delay(&0u64);
 
         (client, admin, treasury)


### PR DESCRIPTION
I've successfully updated the raffle contract to natively support multiple winners and resolved the associated compilation and test errors. Here is a detailed summary of what was changed:

Removed Single-Winner State (raffle-instance/src/lib.rs)

Removed the winner_ticket_id field from the Raffle struct and its corresponding initialization. The contract already had winners: Vec<Address> and claimed_winners: Vec<bool>, which correctly track multiple winners, making winner_ticket_id obsolete.
Fixed Multiple-Winner Event Emission (raffle-instance/src/lib.rs)

In do_finalize_with_seed, the ticket_id emitted in the WinnerDrawn event was incorrectly assigned winner_index (which is 0-indexed) rather than ticket_id (which is correctly 1-indexed). This was fixed so each winner is logged with their correct ticket ID.
Resolved #[contracttype] Missing Macros (raffle-instance/src/lib.rs)

Added the required #[soroban_sdk::contracttype] macro to the Raffle and FairnessMetadata structs, which was causing tests to fail when trying to save these structs into instance/persistent storage.
Fixed Type Safety Issues (raffle-instance/src/lib.rs)

Fixed a compilation error in claim_prize where tier_index (a u32) was being improperly cast and compared to raffle.winners.len() (which natively returns a u32 in Soroban SDK).
Fixed raffle-factory Test Compilation (raffle/Cargo.toml & raffle/src/lib.rs)

Modified raffle-instance/Cargo.toml to include rlib under crate-type so it could be correctly referenced as a dev-dependency for raffle-factory tests.
Added the required soroban_sdk::testutils::Address as _ import for generate to work in raffle-factory tests.
Mocked authorizations via env.mock_all_auths() in factory tests to prevent HostError: Error(Auth, InvalidAction) during the test_init_factory unit test.
Cleaned up an unused u128 import in raffle/src/events.rs.

Close #182