### PR TITLE
fix: validate prizes.len() <= tickets_sold before finalization

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -118,6 +118,7 @@ pub enum Error {
     NotInitialized = 43,
     Reentrancy = 44,
     TokenTransferFailed = 45,
+    MorePrizesThanTickets = 46,
 }
 
 fn read_raffle(env: &Env) -> Result<Raffle, Error> {
@@ -789,6 +790,9 @@ fn do_finalize_with_seed(
     let total_tickets = get_ticket_count(env);
     if total_tickets == 0 {
         return Err(Error::NoTicketsSold);
+    }
+    if raffle.prizes.len() as u32 > total_tickets {
+        return Err(Error::MorePrizesThanTickets);
     }
 
     let selector = OracleSeedWinnerSelection::new(seed);


### PR DESCRIPTION
Fixes #226

## Problem
When `prizes.len()` exceeds the number of sold tickets, winner selection exhausts the ticket pool mid-loop in `do_finalize_with_seed`.

## Fix
- Added `MorePrizesThanTickets = 46` to the `Error` enum
- Added a pre-finalization guard in `do_finalize_with_seed`: returns `Err(Error::MorePrizesThanTickets)` if `prizes.len() > total_tickets`