### PR TITLE
fix: remove unused winner_ticket_id field from Raffle struct

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -57,7 +57,6 @@ pub struct Raffle {
     pub swap_router: Option<Address>,
     pub tikka_token: Option<Address>,
     pub finalized_at: Option<u64>,
-    pub winner_ticket_id: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -272,7 +271,6 @@ impl Contract {
             swap_router: config.swap_router,
             tikka_token: config.tikka_token,
             finalized_at: None,
-            winner_ticket_id: None,
         };
         write_raffle(&env, &raffle);
         env.storage().instance().set(&DataKey::Factory, &factory);


### PR DESCRIPTION
## Summary

Removes the `winner_ticket_id: Option<u32>` field from the `Raffle` struct in `raffle-instance/src/lib.rs`.

This field was assigned `None` on initialization but was never read by any downstream logic. It was wasting ledger storage and creating confusion about whether single-winner vs multi-winner logic was intended — the contract already tracks winners via the `winners: Vec<Address>` field.

## Changes
- Removed `winner_ticket_id` field from `Raffle` struct
- Removed corresponding `winner_ticket_id: None` initializer in `init()`

Closes #228