### PR TITLE
fix: emit RaffleStatusChanged event on Claimed status transition

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -584,6 +584,11 @@ impl Contract {
         }
         if all_claimed {
             raffle.status = RaffleStatus::Claimed;
+            RaffleStatusChanged {
+                old_status: RaffleStatus::Finalized,
+                new_status: RaffleStatus::Claimed,
+                timestamp: env.ledger().timestamp(),
+            }.publish(&env);
         }
         write_raffle(&env, &raffle);
 


### PR DESCRIPTION
## Summary

`claim_prize()` correctly transitions `raffle.status` to `Claimed` once all prizes are claimed, but it never emitted a `RaffleStatusChanged` event for the `Finalized → Claimed` transition. Raffles therefore remained observable as `Finalized` indefinitely, breaking status-based queries and fee-sweep logic.

## Changes
- Emit `RaffleStatusChanged { old_status: Finalized, new_status: Claimed, timestamp }` inside the `all_claimed` branch of `claim_prize()` in `raffle-instance/src/lib.rs`

Closes #229