### PR TITLE
fix: emit CreationRateLimited event with unlock timestamp

### DIFF
--- a/contracts/raffle/src/events.rs
+++ b/contracts/raffle/src/events.rs
@@ -83,3 +83,11 @@ pub struct RaffleCleanedUp {
     pub finish_time: u64,
     pub cleaned_at: u64,
 }
+
+#[derive(Clone)]
+#[contractevent]
+pub struct CreationRateLimited {
+    pub creator: Address,
+    pub unlock_timestamp: u64,
+    pub timestamp: u64,
+}

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -314,6 +314,12 @@ impl RaffleFactory {
                 .unwrap_or(0);
 
             if now < last_creation + min_delay {
+                let unlock_timestamp = last_creation + min_delay;
+                events::CreationRateLimited {
+                    creator: creator.clone(),
+                    unlock_timestamp,
+                    timestamp: now,
+                }.publish(&env);
                 return Err(ContractError::RateLimitExceeded);
             }
 


### PR DESCRIPTION
## Summary

The 5-minute creation rate limit in `create_raffle()` silently returned `RateLimitExceeded` with zero feedback to the caller. Creators had no way to know why creation failed or when they could retry.

## Changes

**`contracts/raffle/src/events.rs`**
- Add `CreationRateLimited` event struct with fields: `creator`, `unlock_timestamp`, `timestamp`

**`contracts/raffle/src/lib.rs`**
- Compute `unlock_timestamp = last_creation + min_delay` before returning the error
- Emit `CreationRateLimited` event so callers and indexers can surface the exact time the creator can retry

Closes #230