### PR TITLE
Award residual prize dust to final tier

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -198,6 +198,37 @@ fn build_internal_seed_u64(env: &Env) -> u64 {
     u64::from_be_bytes(bytes)
 }
 
+fn calculate_tier_prize(raffle: &Raffle, tier_index: u32) -> Result<i128, Error> {
+    let last_tier_index = raffle.prizes.len() - 1;
+
+    if tier_index == last_tier_index {
+        let mut allocated_before_last = 0i128;
+        for i in 0..last_tier_index {
+            let prize_bp = raffle.prizes.get(i).unwrap();
+            let amount = raffle
+                .prize_amount
+                .checked_mul(prize_bp as i128)
+                .ok_or(Error::ArithmeticOverflow)?
+                / 10000;
+            allocated_before_last = allocated_before_last
+                .checked_add(amount)
+                .ok_or(Error::ArithmeticOverflow)?;
+        }
+
+        return raffle
+            .prize_amount
+            .checked_sub(allocated_before_last)
+            .ok_or(Error::ArithmeticOverflow);
+    }
+
+    let prize_bp = raffle.prizes.get(tier_index).unwrap();
+    raffle
+        .prize_amount
+        .checked_mul(prize_bp as i128)
+        .ok_or(Error::ArithmeticOverflow)
+        .map(|amount| amount / 10000)
+}
+
 #[contractimpl]
 impl Contract {
     pub fn init(
@@ -567,8 +598,7 @@ impl Contract {
             return Err(Error::PrizeAlreadyClaimed);
         }
 
-        let prize_bp = raffle.prizes.get(tier_index).unwrap();
-        let amount = raffle.prize_amount.checked_mul(prize_bp as i128).ok_or(Error::ArithmeticOverflow)? / 10000;
+        let amount = calculate_tier_prize(&raffle, tier_index)?;
 
         let fee = amount * (raffle.protocol_fee_bp as i128) / 10000;
         let net_amount = amount - fee;


### PR DESCRIPTION
Closes #219 

## Summary

Fixes #219 by ensuring integer-division dust from multi-tier prize payouts is not silently left undistributed.

## Changes

- Added tier prize calculation helper.
- Preserves normal basis-point payout calculation for all non-final tiers.
- Awards the residual prize amount to the final tier winner:
  `prize_amount - sum(previous tier payouts)`

## Testing

- `git diff --check` passed.
- Could not run Rust tests locally because `cargo`/`rustc` are not available on PATH in this environment.