### PR TITLE
fix(raffle): move NextTicketId to persistent storage

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -133,7 +133,7 @@ fn write_raffle(env: &Env, raffle: &Raffle) {
 
 fn get_ticket_count(env: &Env) -> u32 {
     env.storage()
-        .instance()
+        .persistent()
         .get(&DataKey::NextTicketId)
         .unwrap_or(0u32)
 }
@@ -148,11 +148,11 @@ fn get_ticket_owner(env: &Env, ticket_id: u32) -> Option<Address> {
 fn next_ticket_id(env: &Env) -> u32 {
     let current: u32 = env
         .storage()
-        .instance()
+        .persistent()
         .get(&DataKey::NextTicketId)
         .unwrap_or(0u32);
     let next = current + 1;
-    env.storage().instance().set(&DataKey::NextTicketId, &next);
+    env.storage().persistent().set(&DataKey::NextTicketId, &next);
     next
 }
 


### PR DESCRIPTION
Close #243 


Pull Request Document
Title: Move Ticket ID counter to persistent storage to prevent ID collisions
Description

This PR addresses a critical state management issue where the NextTicketId counter was stored in Instance Storage.

The Problem: Soroban's instance storage has a Time-To-Live (TTL). If a contract is not interacted with and its instance storage expires, all data within that storage—including the ticket counter—is lost. If the contract is later restored or re-initialized, the counter would default back to 0. This would result in new tickets being assigned IDs that were already issued to previous participants, breaking the uniqueness invariant of the raffle and potentially overwriting existing ticket data in persistent storage.

The Solution: I have migrated the NextTicketId logic to use Persistent Storage. Persistent storage entries have an independent lifecycle and are better suited for data that must remain unique and consistent across the entire duration of the contract's existence.
Changes

    File: [/workspaces/tikka-contracts/contracts/raffle-instance/src/lib.rs](code-assist-path:/workspaces/tikka-contracts/contracts/raffle-instance/src/lib.rs)
    Logic: Refactored get_ticket_count and next_ticket_id helper functions to interface with env.storage().persistent() instead of env.storage().instance().

Impact

    Reliability: Prevents ID reuse after contract inactivity.
    Security: Ensures participant records (linked to ticket IDs) cannot be unintentionally overwritten.
    Compliance: Aligns with Soroban best practices for stateful counters.

Verification Results

    Unit Tests: Ran cargo test -p raffle-instance. All tests related to ticket purchasing passed.
    Storage Check: Verified that NextTicketId is correctly recorded in the persistent ledger partition during local testing.Pull Request Document
Title: Move Ticket ID counter to persistent storage to prevent ID collisions
Description

This PR addresses a critical state management issue where the NextTicketId counter was stored in Instance Storage.

The Problem: Soroban's instance storage has a Time-To-Live (TTL). If a contract is not interacted with and its instance storage expires, all data within that storage—including the ticket counter—is lost. If the contract is later restored or re-initialized, the counter would default back to 0. This would result in new tickets being assigned IDs that were already issued to previous participants, breaking the uniqueness invariant of the raffle and potentially overwriting existing ticket data in persistent storage.

The Solution: I have migrated the NextTicketId logic to use Persistent Storage. Persistent storage entries have an independent lifecycle and are better suited for data that must remain unique and consistent across the entire duration of the contract's existence.
Changes

    File: [/workspaces/tikka-contracts/contracts/raffle-instance/src/lib.rs](code-assist-path:/workspaces/tikka-contracts/contracts/raffle-instance/src/lib.rs)
    Logic: Refactored get_ticket_count and next_ticket_id helper functions to interface with env.storage().persistent() instead of env.storage().instance().

Impact

    Reliability: Prevents ID reuse after contract inactivity.
    Security: Ensures participant records (linked to ticket IDs) cannot be unintentionally overwritten.
    Compliance: Aligns with Soroban best practices for stateful counters.

Verification Results

    Unit Tests: Ran cargo test -p raffle-instance. All tests related to ticket purchasing passed.
    Storage Check: Verified that NextTicketId is correctly recorded in the persistent ledger partition during local testing.