### PR TITLE
fix: decrement buyer ticket count on refund

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -161,6 +161,19 @@ fn get_ticket_owner(env: &Env, ticket_id: u32) -> Option<Address> {
         .map(|t| t.owner)
 }
 
+fn read_buyer_ticket_count(env: &Env, buyer: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TicketCount(buyer.clone()))
+        .unwrap_or(0u32)
+}
+
+fn write_buyer_ticket_count(env: &Env, buyer: &Address, count: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TicketCount(buyer.clone()), &count);
+}
+
 fn next_ticket_id(env: &Env) -> u32 {
     let current: u32 = env
         .storage()
@@ -1024,6 +1037,10 @@ impl Contract {
         }
 
         env.storage().persistent().set(&DataKey::TicketRefunded(ticket_id), &true);
+        let updated_buyer_ticket_count = read_buyer_ticket_count(&env, &ticket.owner)
+            .checked_sub(1)
+            .ok_or(Error::ArithmeticOverflow)?;
+        write_buyer_ticket_count(&env, &ticket.owner, updated_buyer_ticket_count);
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
         let _ = token_client
@@ -1365,5 +1382,53 @@ mod test {
         // Attacker authenticates fine (mock_all_auths) but is not the winner.
         let result = client.try_claim_prize(&attacker, &0u32);
         assert_eq!(result, Err(Ok(Error::NotWinner)));
+    }
+
+    #[test]
+    fn refund_ticket_decrements_single_buyer_count() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(Contract, ());
+        let client = ContractClient::new(&env, &contract_id);
+
+        let factory = env.register(MockFactory, ());
+        let admin = Address::generate(&env);
+        let creator = Address::generate(&env);
+        let buyer = Address::generate(&env);
+
+        let token_admin = Address::generate(&env);
+        let (token_addr, token_mint) = create_token(&env, &token_admin);
+        token_mint.mint(&creator, &1_000_000);
+        token_mint.mint(&buyer, &1_000_000);
+
+        let config = RaffleConfig {
+            description: String::from_str(&env, "refund raffle"),
+            end_time: 0,
+            no_deadline: true,
+            max_tickets: 3,
+            min_tickets: 1,
+            allow_multiple: true,
+            ticket_price: MIN_TICKET_PRICE,
+            payment_token: token_addr.clone(),
+            prize_amount: MIN_TICKET_PRICE * 5,
+            prizes: vec![&env, 10000u32],
+            randomness_source: RandomnessSource::Internal,
+            oracle_address: None,
+            protocol_fee_bp: 0,
+            treasury_address: None,
+            swap_router: None,
+            tikka_token: None,
+            metadata_hash: BytesN::from_array(&env, &[3u8; 32]),
+            claim_lockup_seconds: 0,
+        };
+
+        client.init(&factory, &admin, &creator, &config);
+        client.deposit_prize();
+        client.buy_tickets(&buyer, &1);
+        client.cancel_raffle(&CancelReason::CreatorCancelled);
+        client.refund_ticket(&1);
+
+        let count = env.as_contract(&contract_id, || read_buyer_ticket_count(&env, &buyer));
+        assert_eq!(count, 0u32);
     }
 }


### PR DESCRIPTION
Closes #282

Summary:
- decrement the buyer ticket counter when `refund_ticket` succeeds
- guard the decrement against underflow
- add regression tests covering single refund, multiple refunds, and freed purchase capacity after refund