### PR TITLE
feat: add raffle_id to RaffleCreated event for indexer correlation (Issue #264)

### DIFF
--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -4,6 +4,7 @@ use raffle_shared::{CancelReason, RandomnessSource, RandomnessType};
 #[derive(Clone)]
 #[contractevent]
 pub struct RaffleCreated {
+    pub raffle_id: Address,
     pub creator: Address,
     pub end_time: u64,
     pub max_tickets: u32,

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -279,6 +279,7 @@ impl Contract {
         env.storage().instance().set(&DataKey::Admin, &admin);
 
         RaffleCreated {
+            raffle_id: env.current_contract_address(),
             creator,
             end_time: config.end_time,
             max_tickets: config.max_tickets,


### PR DESCRIPTION
## Summary
Add raffle_id field to RaffleCreated event so off-chain indexers can correlate the event to the deployed raffle contract instance.

## Related Issue
Closes #264

## Changes
- Added raffle_id: Address field to RaffleCreated event struct in raffle-instance/src/events.rs
- Populated with env.current_contract_address() at the emission site in raffle-instance/src/lib.rs init()

Off-chain indexers no longer need to parse call-result data to tie RaffleCreated events back to deployed instances.
