### PR TITLE
feat: validate oracle address at init when ExternalRandomness selected (Issue #276)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "contracts/*",
   "fuzz",
 ]
+default-members = ["contracts/*"]
 
 [workspace.dependencies]
 soroban-sdk = "23"

--- a/contracts/raffle-instance/Cargo.toml
+++ b/contracts/raffle-instance/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }

--- a/contracts/raffle-instance/Cargo.toml
+++ b/contracts/raffle-instance/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk = { workspace = true }
 raffle-shared = { path = "../raffle-shared" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{contractevent, Address, BytesN, String, Vec};
 use raffle_shared::{CancelReason, RandomnessSource, RandomnessType};
+use soroban_sdk::{contractevent, Address, BytesN, String, Vec};
 
 #[derive(Clone)]
 #[contractevent]

--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -48,6 +48,7 @@ pub struct TicketPurchased {
     pub timestamp: u64,
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 #[contractevent]
 pub struct DrawTriggered {

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -566,7 +566,7 @@ impl Contract {
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
         let _ = token_client
-            .try_transfer(&buyer, &env.current_contract_address(), &total_price)
+            .try_transfer(&buyer, env.current_contract_address(), &total_price)
             .map_err(|_| Error::TokenTransferFailed)?;
 
         if protocol_fee > 0 {

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -310,7 +310,7 @@ impl Contract {
         if config.prize_amount < config.ticket_price {
             return Err(Error::InvalidParameters);
         }
-        if config.prizes.len() == 0 {
+        if config.prizes.is_empty() {
             return Err(Error::InvalidParameters);
         }
         let mut total_prizes_bp = 0u32;
@@ -494,7 +494,7 @@ impl Contract {
             .checked_mul(raffle.protocol_fee_bp as i128)
             .ok_or(Error::ArithmeticOverflow)?
             / 10000;
-        let net_amount = total_price - protocol_fee;
+        let _net_amount = total_price - protocol_fee;
 
         for _ in 0..quantity {
             let ticket_id = next_ticket_id(&env);

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -10,9 +10,6 @@ use soroban_sdk::{
 mod events;
 mod randomness;
 
-#[cfg(test)]
-mod mock_factory;
-
 use raffle_shared::{
     CancelReason, FairnessData, RaffleConfig, RaffleStatus, RandomnessSource, RandomnessType,
     Ticket,

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -2,28 +2,25 @@
 
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    contract, contracterror, contractimpl, token, xdr::ToXdr, Address, Bytes, BytesN,
-    Env, IntoVal, String, Symbol, Val, Vec,
+    contract, contracterror, contractimpl, token,
+    xdr::ToXdr,
+    Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Val, Vec,
 };
 
-mod randomness;
 mod events;
+mod randomness;
 
 use raffle_shared::{
-    RaffleConfig, RaffleStatus, CancelReason, RandomnessSource, RandomnessType,
-    Ticket, FairnessData,
+    CancelReason, FairnessData, RaffleConfig, RaffleStatus, RandomnessSource, RandomnessType,
+    Ticket,
 };
 
-use self::randomness::{
-    OracleSeedWinnerSelection, WinnerSelectionStrategy,
-};
+use self::randomness::{OracleSeedWinnerSelection, WinnerSelectionStrategy};
 
 use crate::events::{
-    DrawTriggered, PrizeClaimed, PrizeDeposited, PrizeRefunded, RaffleCancelled, RaffleCreated,
-    RaffleFinalized, RaffleStatusChanged, RandomnessReceived,
-    RandomnessRequested, TicketPurchased, TicketRefunded,
-    WinnerDrawn, RandomnessFallbackTriggered,
-    ContractPaused, ContractUnpaused,
+    ContractPaused, ContractUnpaused, PrizeClaimed, PrizeDeposited, PrizeRefunded, RaffleCancelled,
+    RaffleCreated, RaffleFinalized, RaffleStatusChanged, RandomnessFallbackTriggered,
+    RandomnessReceived, RandomnessRequested, TicketPurchased, TicketRefunded, WinnerDrawn,
 };
 
 const ORACLE_TIMEOUT_LEDGERS: u32 = 200;
@@ -130,8 +127,10 @@ pub enum Error {
     NotInitialized = 43,
     Reentrancy = 44,
     TokenTransferFailed = 45,
-    DeadlinePassed = 46,
-    SlippageExceeded = 47,
+    DeadlinePassed = 47,
+    SlippageExceeded = 48,
+    InvalidIndex = 49,
+    MorePrizesThanTickets = 50,
 }
 
 fn read_raffle(env: &Env) -> Result<Raffle, Error> {
@@ -166,7 +165,9 @@ fn next_ticket_id(env: &Env) -> u32 {
         .get(&DataKey::NextTicketId)
         .unwrap_or(0u32);
     let next = current + 1;
-    env.storage().persistent().set(&DataKey::NextTicketId, &next);
+    env.storage()
+        .persistent()
+        .set(&DataKey::NextTicketId, &next);
     next
 }
 
@@ -181,7 +182,12 @@ fn acquire_guard(env: &Env) -> Result<(), Error> {
 }
 
 // Helper to enforce slippage and deadline guards for token swaps
-fn enforce_swap_guard(env: &Env, amount_out: i128, min_amount_out: i128, deadline: u64) -> Result<(), Error> {
+fn enforce_swap_guard(
+    env: &Env,
+    amount_out: i128,
+    min_amount_out: i128,
+    deadline: u64,
+) -> Result<(), Error> {
     // Check deadline
     if env.ledger().timestamp() > deadline {
         return Err(Error::DeadlinePassed);
@@ -329,7 +335,8 @@ impl Contract {
             }
         }
 
-        if config.randomness_source != RandomnessSource::External && config.oracle_address.is_some() {
+        if config.randomness_source != RandomnessSource::External && config.oracle_address.is_some()
+        {
             return Err(Error::InvalidParameters);
         }
 
@@ -390,7 +397,8 @@ impl Contract {
             description: config.description,
             randomness_source: config.randomness_source,
             metadata_hash: config.metadata_hash,
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -431,19 +439,23 @@ impl Contract {
             amount: raffle.prize_amount,
             token: raffle.payment_token.clone(),
             timestamp,
-        }.publish(&env);
+        }
+        .publish(&env);
 
         RaffleStatusChanged {
             old_status,
             new_status: RaffleStatus::Active,
             timestamp,
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
 
     pub fn buy_tickets(env: Env, buyer: Address, quantity: u32) -> Result<u32, Error> {
-        require!(quantity > 0, Error::InvalidQuantity);
+        if quantity == 0 {
+            return Err(Error::InvalidQuantity);
+        }
         let mut raffle = read_raffle(&env)?;
         buyer.require_auth();
         require_not_paused(&env)?;
@@ -462,7 +474,11 @@ impl Contract {
             return Err(Error::TicketsSoldOut);
         }
 
-        let current_count: u32 = env.storage().persistent().get(&DataKey::TicketCount(buyer.clone())).unwrap_or(0);
+        let current_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TicketCount(buyer.clone()))
+            .unwrap_or(0);
         if !raffle.allow_multiple && (current_count > 0 || quantity > 1) {
             return Err(Error::MultipleTicketsNotAllowed);
         }
@@ -476,7 +492,8 @@ impl Contract {
 
         let protocol_fee = total_price
             .checked_mul(raffle.protocol_fee_bp as i128)
-            .ok_or(Error::ArithmeticOverflow)? / 10000;
+            .ok_or(Error::ArithmeticOverflow)?
+            / 10000;
         let net_amount = total_price - protocol_fee;
 
         for _ in 0..quantity {
@@ -489,7 +506,9 @@ impl Contract {
                 purchase_time: timestamp,
                 ticket_number: raffle.tickets_sold,
             };
-            env.storage().persistent().set(&DataKey::Ticket(ticket_id), &ticket);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Ticket(ticket_id), &ticket);
             ticket_ids.push_back(ticket_id);
         }
 
@@ -500,17 +519,28 @@ impl Contract {
                 old_status,
                 new_status: RaffleStatus::Drawing,
                 timestamp,
-            }.publish(&env);
+            }
+            .publish(&env);
         }
 
-        env.storage().persistent().set(&DataKey::TicketCount(buyer.clone()), &(current_count + quantity));
+        env.storage().persistent().set(
+            &DataKey::TicketCount(buyer.clone()),
+            &(current_count + quantity),
+        );
         write_raffle(&env, &raffle);
 
-        if let Some(factory_address) = env.storage().instance().get::<_, Address>(&DataKey::Factory) {
+        if let Some(factory_address) = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::Factory)
+        {
             let contract_address = env.current_contract_address();
-            let record_volume_args: Vec<Val> =
-                (contract_address.clone(), raffle.payment_token.clone(), total_price)
-                    .into_val(&env);
+            let record_volume_args: Vec<Val> = (
+                contract_address.clone(),
+                raffle.payment_token.clone(),
+                total_price,
+            )
+                .into_val(&env);
 
             env.authorize_as_current_contract(Vec::from_array(
                 &env,
@@ -544,8 +574,14 @@ impl Contract {
             if let Some(treasury) = &raffle.treasury_address {
                 token_client.transfer(&env.current_contract_address(), treasury, &protocol_fee);
             }
-            let prev_fees: i128 = env.storage().instance().get(&DataKey::AccumulatedFees).unwrap_or(0);
-            env.storage().instance().set(&DataKey::AccumulatedFees, &(prev_fees + protocol_fee));
+            let prev_fees: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AccumulatedFees)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&DataKey::AccumulatedFees, &(prev_fees + protocol_fee));
         }
 
         TicketPurchased {
@@ -556,7 +592,8 @@ impl Contract {
             total_paid: total_price,
             protocol_fee,
             timestamp,
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(raffle.tickets_sold)
     }
@@ -586,38 +623,54 @@ impl Contract {
                 old_status,
                 new_status: RaffleStatus::Failed,
                 timestamp: now,
-            }.publish(&env);
+            }
+            .publish(&env);
             return Ok(());
         }
 
         if raffle.randomness_source == RandomnessSource::External {
-            let already: bool = env.storage().instance().get(&DataKey::RandomnessRequested).unwrap_or(false);
+            let already: bool = env
+                .storage()
+                .instance()
+                .get(&DataKey::RandomnessRequested)
+                .unwrap_or(false);
             if already {
                 return Err(Error::RandomnessAlreadyRequested);
             }
-            
+
             // Generate unique request ID to prevent replay attacks
-            let request_id_seed = Bytes::from_array(&env, &(
+            let request_id_xdr = (
                 env.ledger().timestamp(),
                 env.ledger().sequence(),
                 env.current_contract_address().to_xdr(&env),
-            ).to_xdr(&env));
-            let request_id_hash: BytesN<32> = env.crypto().sha256(&request_id_seed).into();
+            )
+                .to_xdr(&env);
+            let request_id_hash: BytesN<32> = env.crypto().sha256(&request_id_xdr).into();
             let mut id_bytes = [0u8; 8];
             for i in 0..8 {
                 id_bytes[i] = request_id_hash.get(i as u32).unwrap();
             }
             let request_id = u64::from_be_bytes(id_bytes);
-            
-            env.storage().instance().set(&DataKey::RandomnessRequested, &true);
-            env.storage().instance().set(&DataKey::RandomnessRequestLedger, &env.ledger().sequence());
-            env.storage().instance().set(&DataKey::RandomnessRequestId, &request_id);
+
+            env.storage()
+                .instance()
+                .set(&DataKey::RandomnessRequested, &true);
+            env.storage()
+                .instance()
+                .set(&DataKey::RandomnessRequestLedger, &env.ledger().sequence());
+            env.storage()
+                .instance()
+                .set(&DataKey::RandomnessRequestId, &request_id);
 
             RandomnessRequested {
-                oracle: raffle.oracle_address.clone().unwrap_or(env.current_contract_address()),
+                oracle: raffle
+                    .oracle_address
+                    .clone()
+                    .unwrap_or(env.current_contract_address()),
                 request_id,
                 timestamp: now,
-            }.publish(&env);
+            }
+            .publish(&env);
             return Ok(());
         }
 
@@ -646,13 +699,21 @@ impl Contract {
             return Err(Error::InvalidStateTransition);
         }
 
-        let request_pending: bool = env.storage().instance().get(&DataKey::RandomnessRequested).unwrap_or(false);
+        let request_pending: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::RandomnessRequested)
+            .unwrap_or(false);
         if !request_pending {
             return Err(Error::NoRandomnessRequest);
         }
 
         // Verify request ID to prevent replay attacks
-        let stored_request_id: u64 = env.storage().instance().get(&DataKey::RandomnessRequestId).ok_or(Error::NoRandomnessRequest)?;
+        let stored_request_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RandomnessRequestId)
+            .ok_or(Error::NoRandomnessRequest)?;
         if stored_request_id != request_id {
             return Err(Error::InvalidParameters);
         }
@@ -665,17 +726,26 @@ impl Contract {
             seed: random_seed,
             request_id,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         self::do_finalize_with_seed(&env, raffle, random_seed, RandomnessType::Vrf)?;
         Ok(env.current_contract_address())
     }
 
-    pub fn trigger_randomness_fallback(env: Env, caller: Address, do_refund: bool) -> Result<(), Error> {
+    pub fn trigger_randomness_fallback(
+        env: Env,
+        caller: Address,
+        do_refund: bool,
+    ) -> Result<(), Error> {
         caller.require_auth();
         let mut raffle = read_raffle(&env)?;
 
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
         if caller != raffle.creator && caller != admin {
             return Err(Error::NotAuthorized);
         }
@@ -684,12 +754,20 @@ impl Contract {
             return Err(Error::InvalidStateTransition);
         }
 
-        let request_pending: bool = env.storage().instance().get(&DataKey::RandomnessRequested).unwrap_or(false);
+        let request_pending: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::RandomnessRequested)
+            .unwrap_or(false);
         if !request_pending {
             return Err(Error::NoRandomnessRequest);
         }
 
-        let request_ledger: u32 = env.storage().instance().get(&DataKey::RandomnessRequestLedger).unwrap_or(0);
+        let request_ledger: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RandomnessRequestLedger)
+            .unwrap_or(0);
         if env.ledger().sequence() < request_ledger + ORACLE_TIMEOUT_LEDGERS {
             return Err(Error::FallbackTooEarly);
         }
@@ -704,19 +782,21 @@ impl Contract {
                 tickets_sold: raffle.tickets_sold,
                 prize_refunded: raffle.prize_deposited,
                 timestamp: env.ledger().timestamp(),
-            }.publish(&env);
+            }
+            .publish(&env);
             return Ok(());
         }
 
         let seed = build_internal_seed_u64(&env);
-        
+
         RandomnessFallbackTriggered {
             triggered_by: caller,
             seed_used: seed,
             request_ledger,
             fallback_ledger: env.ledger().sequence(),
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         self::do_finalize_with_seed(&env, raffle, seed, RandomnessType::Fallback)
     }
@@ -737,7 +817,7 @@ impl Contract {
             }
         }
 
-        if tier_index as usize >= raffle.winners.len() {
+        if tier_index >= raffle.winners.len() {
             return Err(Error::InvalidParameters);
         }
 
@@ -745,7 +825,11 @@ impl Contract {
             return Err(Error::NotWinner);
         }
 
-        if raffle.claimed_winners.get(tier_index).ok_or(Error::InvalidIndex)? {
+        if raffle
+            .claimed_winners
+            .get(tier_index)
+            .ok_or(Error::InvalidIndex)?
+        {
             return Err(Error::PrizeAlreadyClaimed);
         }
 
@@ -755,7 +839,7 @@ impl Contract {
         let net_amount = amount - fee;
 
         raffle.claimed_winners.set(tier_index, true);
-        
+
         let mut all_claimed = true;
         for claimed in raffle.claimed_winners.iter() {
             if !claimed {
@@ -769,7 +853,8 @@ impl Contract {
                 old_status: RaffleStatus::Finalized,
                 new_status: RaffleStatus::Claimed,
                 timestamp: env.ledger().timestamp(),
-            }.publish(&env);
+            }
+            .publish(&env);
         }
         write_raffle(&env, &raffle);
 
@@ -784,8 +869,14 @@ impl Contract {
                     .try_transfer(&env.current_contract_address(), treasury, &fee)
                     .map_err(|_| Error::TokenTransferFailed)?;
             }
-            let prev_fees: i128 = env.storage().instance().get(&DataKey::AccumulatedFees).unwrap_or(0);
-            env.storage().instance().set(&DataKey::AccumulatedFees, &(prev_fees + fee));
+            let prev_fees: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AccumulatedFees)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&DataKey::AccumulatedFees, &(prev_fees + fee));
         }
 
         PrizeClaimed {
@@ -796,7 +887,8 @@ impl Contract {
             net_amount,
             platform_fee: fee,
             claimed_at: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(net_amount)
     }
@@ -806,13 +898,20 @@ impl Contract {
 
         match reason {
             CancelReason::AdminCancelled => {
-                let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
+                let admin: Address = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Admin)
+                    .ok_or(Error::NotAuthorized)?;
                 admin.require_auth();
             }
             _ => raffle.creator.require_auth(),
         }
 
-        if raffle.status == RaffleStatus::Finalized || raffle.status == RaffleStatus::Cancelled || raffle.status == RaffleStatus::Claimed {
+        if raffle.status == RaffleStatus::Finalized
+            || raffle.status == RaffleStatus::Cancelled
+            || raffle.status == RaffleStatus::Claimed
+        {
             return Err(Error::InvalidStatus);
         }
 
@@ -826,7 +925,8 @@ impl Contract {
             tickets_sold: raffle.tickets_sold,
             prize_refunded: raffle.prize_deposited,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -848,7 +948,11 @@ impl Contract {
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
         token_client
-            .try_transfer(&env.current_contract_address(), &raffle.creator, &raffle.prize_amount)
+            .try_transfer(
+                &env.current_contract_address(),
+                &raffle.creator,
+                &raffle.prize_amount,
+            )
             .map_err(|_| Error::TokenTransferFailed)?;
 
         PrizeRefunded {
@@ -856,7 +960,8 @@ impl Contract {
             amount: raffle.prize_amount,
             token: raffle.payment_token.clone(),
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -872,7 +977,11 @@ impl Contract {
         }
 
         let _guard = Guard::new(&env)?;
-        let ticket: Ticket = env.storage().persistent().get(&DataKey::Ticket(ticket_id)).ok_or(Error::TicketNotFound)?;
+        let ticket: Ticket = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Ticket(ticket_id))
+            .ok_or(Error::TicketNotFound)?;
         ticket.owner.require_auth();
 
         // Check if already refunded
@@ -885,7 +994,11 @@ impl Contract {
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
         token_client
-            .try_transfer(&env.current_contract_address(), &ticket.owner, &raffle.ticket_price)
+            .try_transfer(
+                &env.current_contract_address(),
+                &ticket.owner,
+                &raffle.ticket_price,
+            )
             .map_err(|_| Error::TokenTransferFailed)?;
 
         TicketRefunded {
@@ -893,7 +1006,8 @@ impl Contract {
             ticket_number: ticket.ticket_number,
             amount: raffle.ticket_price,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(raffle.ticket_price)
     }
@@ -903,9 +1017,13 @@ impl Contract {
     }
 
     pub fn get_fairness_data(env: Env) -> Result<FairnessData, Error> {
-        let metadata: FairnessMetadata = env.storage().instance().get(&DataKey::RandomnessSeed).ok_or(Error::InvalidStatus)?;
+        let metadata: FairnessMetadata = env
+            .storage()
+            .instance()
+            .get(&DataKey::RandomnessSeed)
+            .ok_or(Error::InvalidStatus)?;
         let raffle = read_raffle(&env)?;
-        
+
         let mut ticket_ids = Vec::new(&env);
         let count = get_ticket_count(&env);
         for i in 1..=count {
@@ -923,11 +1041,18 @@ impl Contract {
     }
 
     pub fn wipe_storage(env: Env) -> Result<(), Error> {
-        let factory: Address = env.storage().instance().get(&DataKey::Factory).ok_or(Error::NotAuthorized)?;
+        let factory: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Factory)
+            .ok_or(Error::NotAuthorized)?;
         factory.require_auth();
 
         let raffle = read_raffle(&env)?;
-        if raffle.status != RaffleStatus::Cancelled && raffle.status != RaffleStatus::Claimed && raffle.status != RaffleStatus::Failed {
+        if raffle.status != RaffleStatus::Cancelled
+            && raffle.status != RaffleStatus::Claimed
+            && raffle.status != RaffleStatus::Failed
+        {
             return Err(Error::InvalidStatus);
         }
 
@@ -938,27 +1063,37 @@ impl Contract {
     }
 
     pub fn pause(env: Env) -> Result<(), Error> {
-        let factory: Address = env.storage().instance().get(&DataKey::Factory).ok_or(Error::NotAuthorized)?;
+        let factory: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Factory)
+            .ok_or(Error::NotAuthorized)?;
         factory.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
 
         ContractPaused {
             paused_by: factory,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
 
     pub fn unpause(env: Env) -> Result<(), Error> {
-        let factory: Address = env.storage().instance().get(&DataKey::Factory).ok_or(Error::NotAuthorized)?;
+        let factory: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Factory)
+            .ok_or(Error::NotAuthorized)?;
         factory.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
 
         ContractUnpaused {
             unpaused_by: factory,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -971,7 +1106,11 @@ impl Contract {
     }
 
     pub fn set_admin(env: Env, new_admin: Address) -> Result<(), Error> {
-        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         Ok(())
@@ -1016,7 +1155,8 @@ fn do_finalize_with_seed(
             ticket_id: winner_index,
             tier_index: i,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
     }
 
     let mut claimed_winners = Vec::new(env);
@@ -1042,9 +1182,15 @@ fn do_finalize_with_seed(
     write_raffle(env, &raffle);
 
     // Clear pending randomness state
-    env.storage().instance().remove(&DataKey::RandomnessRequested);
-    env.storage().instance().remove(&DataKey::RandomnessRequestId);
-    env.storage().instance().remove(&DataKey::RandomnessRequestLedger);
+    env.storage()
+        .instance()
+        .remove(&DataKey::RandomnessRequested);
+    env.storage()
+        .instance()
+        .remove(&DataKey::RandomnessRequestId);
+    env.storage()
+        .instance()
+        .remove(&DataKey::RandomnessRequestLedger);
 
     RaffleFinalized {
         winners,
@@ -1053,7 +1199,8 @@ fn do_finalize_with_seed(
         randomness_source: raffle.randomness_source.clone(),
         randomness_type,
         finalized_at: env.ledger().timestamp(),
-    }.publish(&env);
+    }
+    .publish(&env);
 
     Ok(())
 }

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -319,8 +319,17 @@ impl Contract {
             return Err(Error::InvalidParameters);
         }
 
-        if config.randomness_source == RandomnessSource::External && config.oracle_address.is_none()
-        {
+        if config.randomness_source == RandomnessSource::External {
+            match config.oracle_address {
+                None => return Err(Error::InvalidParameters),
+                Some(ref addr) if *addr == env.current_contract_address() => {
+                    return Err(Error::InvalidParameters);
+                }
+                Some(_) => {}
+            }
+        }
+
+        if config.randomness_source != RandomnessSource::External && config.oracle_address.is_some() {
             return Err(Error::InvalidParameters);
         }
 

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -10,6 +10,9 @@ use soroban_sdk::{
 mod events;
 mod randomness;
 
+#[cfg(test)]
+mod mock_factory;
+
 use raffle_shared::{
     CancelReason, FairnessData, RaffleConfig, RaffleStatus, RandomnessSource, RandomnessType,
     Ticket,

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -182,6 +182,7 @@ fn acquire_guard(env: &Env) -> Result<(), Error> {
 }
 
 // Helper to enforce slippage and deadline guards for token swaps
+#[allow(dead_code)]
 fn enforce_swap_guard(
     env: &Env,
     amount_out: i128,
@@ -240,11 +241,9 @@ fn build_internal_seed_u64(env: &Env) -> u64 {
     )
         .to_xdr(env);
     let hash: BytesN<32> = env.crypto().sha256(&xdr).into();
-
+    let arr = hash.to_array();
     let mut bytes = [0u8; 8];
-    for i in 0..8 {
-        bytes[i] = hash.get(i as u32).unwrap();
-    }
+    bytes.copy_from_slice(&arr[..8]);
     u64::from_be_bytes(bytes)
 }
 
@@ -418,7 +417,7 @@ impl Contract {
         // (prize_deposited flag, raffle.status) to remain untouched.
         let token_client = token::Client::new(&env, &raffle.payment_token);
         let contract_address = env.current_contract_address();
-        token_client
+        let _ = token_client
             .try_transfer(&raffle.creator, &contract_address, &raffle.prize_amount)
             .map_err(|_| Error::TokenTransferFailed)?;
 
@@ -566,7 +565,7 @@ impl Contract {
         }
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
-        token_client
+        let _ = token_client
             .try_transfer(&buyer, &env.current_contract_address(), &total_price)
             .map_err(|_| Error::TokenTransferFailed)?;
 
@@ -646,10 +645,9 @@ impl Contract {
             )
                 .to_xdr(&env);
             let request_id_hash: BytesN<32> = env.crypto().sha256(&request_id_xdr).into();
+            let arr = request_id_hash.to_array();
             let mut id_bytes = [0u8; 8];
-            for i in 0..8 {
-                id_bytes[i] = request_id_hash.get(i as u32).unwrap();
-            }
+            id_bytes.copy_from_slice(&arr[..8]);
             let request_id = u64::from_be_bytes(id_bytes);
 
             env.storage()
@@ -685,7 +683,7 @@ impl Contract {
         proof: BytesN<64>,
         request_id: u64,
     ) -> Result<Address, Error> {
-        let mut raffle = read_raffle(&env)?;
+        let raffle = read_raffle(&env)?;
 
         let oracle = match &raffle.oracle_address {
             Some(addr) => {
@@ -859,13 +857,13 @@ impl Contract {
         write_raffle(&env, &raffle);
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
-        token_client
+        let _ = token_client
             .try_transfer(&env.current_contract_address(), &winner, &net_amount)
             .map_err(|_| Error::TokenTransferFailed)?;
 
         if fee > 0 {
             if let Some(treasury) = &raffle.treasury_address {
-                token_client
+                let _ = token_client
                     .try_transfer(&env.current_contract_address(), treasury, &fee)
                     .map_err(|_| Error::TokenTransferFailed)?;
             }
@@ -915,7 +913,6 @@ impl Contract {
             return Err(Error::InvalidStatus);
         }
 
-        let old_status = raffle.status.clone();
         raffle.status = RaffleStatus::Cancelled;
         write_raffle(&env, &raffle);
 
@@ -947,7 +944,7 @@ impl Contract {
         write_raffle(&env, &raffle);
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
-        token_client
+        let _ = token_client
             .try_transfer(
                 &env.current_contract_address(),
                 &raffle.creator,
@@ -993,7 +990,7 @@ impl Contract {
         env.storage().persistent().set(&refund_key, &true);
 
         let token_client = token::Client::new(&env, &raffle.payment_token);
-        token_client
+        let _ = token_client
             .try_transfer(
                 &env.current_contract_address(),
                 &ticket.owner,
@@ -1022,8 +1019,6 @@ impl Contract {
             .instance()
             .get(&DataKey::RandomnessSeed)
             .ok_or(Error::InvalidStatus)?;
-        let raffle = read_raffle(&env)?;
-
         let mut ticket_ids = Vec::new(&env);
         let count = get_ticket_count(&env);
         for i in 1..=count {
@@ -1127,7 +1122,7 @@ fn do_finalize_with_seed(
     if total_tickets == 0 {
         return Err(Error::NoTicketsSold);
     }
-    if raffle.prizes.len() as u32 > total_tickets {
+    if raffle.prizes.len() > total_tickets {
         return Err(Error::MorePrizesThanTickets);
     }
 
@@ -1141,7 +1136,7 @@ fn do_finalize_with_seed(
 
     let selector = OracleSeedWinnerSelection::new(seed);
     let winning_ticket_ids =
-        selector.select_winner_indices(env, total_tickets, raffle.prizes.len() as u32);
+        selector.select_winner_indices(env, total_tickets, raffle.prizes.len());
     let mut winners = Vec::new(env);
 
     for i in 0..winning_ticket_ids.len() {
@@ -1156,7 +1151,7 @@ fn do_finalize_with_seed(
             tier_index: i,
             timestamp: env.ledger().timestamp(),
         }
-        .publish(&env);
+        .publish(env);
     }
 
     let mut claimed_winners = Vec::new(env);
@@ -1200,7 +1195,7 @@ fn do_finalize_with_seed(
         randomness_type,
         finalized_at: env.ledger().timestamp(),
     }
-    .publish(&env);
+    .publish(env);
 
     Ok(())
 }

--- a/contracts/raffle-instance/src/mock_factory.rs
+++ b/contracts/raffle-instance/src/mock_factory.rs
@@ -1,9 +1,0 @@
-use soroban_sdk::{contractimpl, Address, Env};
-
-pub struct MockFactory;
-
-#[contractimpl]
-impl MockFactory {
-    pub fn record_volume(_env: Env, _contract: Address, _token: Address, _amount: i128) {}
-    pub fn track_participant(_env: Env, _participant: Address) {}
-}

--- a/contracts/raffle-instance/src/mock_factory.rs
+++ b/contracts/raffle-instance/src/mock_factory.rs
@@ -1,0 +1,9 @@
+use soroban_sdk::{contractimpl, Address, Env};
+
+pub struct MockFactory;
+
+#[contractimpl]
+impl MockFactory {
+    pub fn record_volume(_env: Env, _contract: Address, _token: Address, _amount: i128) {}
+    pub fn track_participant(_env: Env, _participant: Address) {}
+}

--- a/contracts/raffle-instance/src/randomness.rs
+++ b/contracts/raffle-instance/src/randomness.rs
@@ -189,12 +189,14 @@ impl WinnerSelectionStrategy for OracleSeedWinnerSelection {
                 }
                 // Mix the seed to get a new candidate; wrapping_mul with a
                 // large odd constant provides a fast, bias-free step.
-                current_seed = current_seed.wrapping_mul(6364136223846793005)
+                current_seed = current_seed
+                    .wrapping_mul(6364136223846793005)
                     .wrapping_add(1442695040888963407);
             };
             indices.push_back(idx);
             // Advance the seed for the next winner so picks are independent.
-            current_seed = current_seed.wrapping_mul(6364136223846793005)
+            current_seed = current_seed
+                .wrapping_mul(6364136223846793005)
                 .wrapping_add(1442695040888963407);
         }
 
@@ -274,7 +276,11 @@ mod tests {
             .address();
 
         let seed = env.as_contract(&contract, || build_internal_seed(&env, &raffle_id));
-        assert_ne!(seed.to_array(), [0u8; 32], "sha256 output must not be all zero");
+        assert_ne!(
+            seed.to_array(),
+            [0u8; 32],
+            "sha256 output must not be all zero"
+        );
     }
 
     /// PRNG selections fall within [0, total_tickets).

--- a/contracts/raffle-instance/src/randomness.rs
+++ b/contracts/raffle-instance/src/randomness.rs
@@ -45,6 +45,7 @@ use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env, Vec};
 /// **For low-stakes raffles only.**  See the module-level comment for a full
 /// explanation of the limitations and the recommended alternative for
 /// high-value draws.
+#[allow(dead_code)]
 pub fn build_internal_seed(env: &Env, raffle_id: &Address) -> BytesN<32> {
     let timestamp = env.ledger().timestamp();
     let sequence = env.ledger().sequence();
@@ -63,6 +64,7 @@ pub fn build_internal_seed(env: &Env, raffle_id: &Address) -> BytesN<32> {
 /// In that case we expect the returned hash to be invalid rather than silently
 /// falling back to a zeroed seed, which would make winner selection
 /// deterministic and insecure.
+#[allow(dead_code)]
 fn hash_bytes32(env: &Env, input: &Bytes) -> BytesN<32> {
     let hash: BytesN<32> = env.crypto().sha256(input).into();
     if hash.to_array() == [0u8; 32] {
@@ -84,13 +86,15 @@ pub trait WinnerSelectionStrategy {
 ///
 /// **For low-stakes raffles only** — see [`build_internal_seed`] for the full
 /// security caveat.
+#[allow(dead_code)]
 pub struct PrngWinnerSelection {
-    timestamp: u64,
-    sequence: u32,
-    raffle_id: Address,
-    tickets_sold: u32,
+    pub timestamp: u64,
+    pub sequence: u32,
+    pub raffle_id: Address,
+    pub tickets_sold: u32,
 }
 
+#[allow(dead_code)]
 impl PrngWinnerSelection {
     pub fn new(timestamp: u64, sequence: u32, raffle_id: Address, tickets_sold: u32) -> Self {
         Self {

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -3,6 +3,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
     Address, BytesN, Env,
 };
 
@@ -16,7 +17,12 @@ fn test_oracle_fallback_with_ledger_delays() {
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
     let oracle = Address::generate(&env);
-    let payment_token = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let payment_token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = StellarAssetClient::new(&env, &payment_token);
+    token_client.mint(&creator, &100_000_000);
 
     #[allow(deprecated)]
     let contract_id = env.register_contract(None, Contract);

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, BytesN};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env,
+};
 
 #[test]
 fn test_oracle_fallback_with_ledger_delays() {
@@ -67,7 +70,7 @@ fn test_oracle_fallback_with_ledger_delays() {
     // 9. Verify finalized state
     let raffle_after = client.get_raffle();
     assert_eq!(raffle_after.status, RaffleStatus::Finalized);
-    
+
     // We can also verify the fairness data
     let fairness = client.get_fairness_data();
     assert_eq!(fairness.randomness_source, RandomnessSource::External);

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -7,15 +7,13 @@ use soroban_sdk::{
     Address, BytesN, Env,
 };
 
-use crate::mock_factory::MockFactory;
-
 #[test]
 fn test_oracle_fallback_with_ledger_delays() {
     let env = Env::default();
     env.mock_all_auths();
 
     // 1. Setup factory, admin, creator
-    let factory = env.register(MockFactory, ());
+    let factory = Address::generate(&env);
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
     let oracle = Address::generate(&env);
@@ -51,6 +49,11 @@ fn test_oracle_fallback_with_ledger_delays() {
     };
 
     client.init(&factory, &admin, &creator, &config);
+
+    // Remove factory from storage so buy_tickets skips the factory code path
+    env.as_contract(&contract_id, || {
+        env.storage().instance().remove(&DataKey::Factory);
+    });
 
     // 3. Deposit prize and buy ticket
     client.deposit_prize();

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -18,7 +18,7 @@ fn test_oracle_fallback_with_ledger_delays() {
     let oracle = Address::generate(&env);
     let payment_token = Address::generate(&env);
 
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(None, Contract);
     let client = ContractClient::new(&env, &contract_id);
 
     // 2. Initialize Raffle with External Randomness
@@ -39,6 +39,7 @@ fn test_oracle_fallback_with_ledger_delays() {
         swap_router: None,
         tikka_token: None,
         metadata_hash: BytesN::from_array(&env, &[1; 32]),
+        claim_lockup_seconds: 0,
     };
 
     client.init(&factory, &admin, &creator, &config);
@@ -55,17 +56,17 @@ fn test_oracle_fallback_with_ledger_delays() {
     assert_eq!(raffle.status, RaffleStatus::Drawing);
 
     // 6. Attempt fallback too early
-    let result = client.try_trigger_randomness_fallback(&creator);
+    let result = client.try_trigger_randomness_fallback(&creator, &true);
     assert_eq!(result.err(), Some(Ok(Error::FallbackTooEarly)));
 
     // 7. Simulate ledger delays
     env.ledger().with_mut(|l| {
-        l.sequence += ORACLE_TIMEOUT_LEDGERS + 1;
+        l.sequence_number += ORACLE_TIMEOUT_LEDGERS + 1;
         l.timestamp += 86400; // 1 day
     });
 
     // 8. Trigger fallback successfully
-    client.trigger_randomness_fallback(&creator);
+    client.trigger_randomness_fallback(&creator, &true);
 
     // 9. Verify finalized state
     let raffle_after = client.get_raffle();

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -18,7 +18,8 @@ fn test_oracle_fallback_with_ledger_delays() {
     let oracle = Address::generate(&env);
     let payment_token = Address::generate(&env);
 
-    let contract_id = env.register(None, Contract);
+    #[allow(deprecated)]
+    let contract_id = env.register_contract(None, Contract);
     let client = ContractClient::new(&env, &contract_id);
 
     // 2. Initialize Raffle with External Randomness

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -7,13 +7,26 @@ use soroban_sdk::{
     Address, BytesN, Env,
 };
 
+mod mock_factory {
+    use soroban_sdk::{contractimpl, Address, Env};
+
+    pub struct MockFactory;
+
+    #[contractimpl]
+    impl MockFactory {
+        pub fn record_volume(_env: Env, _contract: Address, _token: Address, _amount: i128) {}
+        pub fn track_participant(_env: Env, _participant: Address) {}
+    }
+}
+
 #[test]
 fn test_oracle_fallback_with_ledger_delays() {
     let env = Env::default();
     env.mock_all_auths();
 
     // 1. Setup factory, admin, creator
-    let factory = Address::generate(&env);
+    let factory_id = env.register_contract(None, mock_factory::MockFactory);
+    let factory = factory_id.address();
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
     let oracle = Address::generate(&env);

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -57,7 +57,7 @@ fn test_oracle_fallback_with_ledger_delays() {
 
     // 3. Deposit prize and buy ticket
     client.deposit_prize();
-    client.buy_tickets(&creator, &1);
+    client.buy_tickets(&creator, &10);
 
     // 4. Finalize raffle (requests randomness)
     client.finalize_raffle();

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -3,7 +3,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    token::{StellarAssetClient, TokenClient},
+    token::StellarAssetClient,
     Address, BytesN, Env,
 };
 

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -57,7 +57,7 @@ fn test_oracle_fallback_with_ledger_delays() {
     assert_eq!(raffle.status, RaffleStatus::Drawing);
 
     // 6. Attempt fallback too early
-    let result = client.try_trigger_randomness_fallback(&creator, &true);
+    let result = client.try_trigger_randomness_fallback(&creator, &false);
     assert_eq!(result.err(), Some(Ok(Error::FallbackTooEarly)));
 
     // 7. Simulate ledger delays
@@ -66,8 +66,8 @@ fn test_oracle_fallback_with_ledger_delays() {
         l.timestamp += 86400; // 1 day
     });
 
-    // 8. Trigger fallback successfully
-    client.trigger_randomness_fallback(&creator, &true);
+    // 8. Trigger fallback successfully (no refund — finalize)
+    client.trigger_randomness_fallback(&creator, &false);
 
     // 9. Verify finalized state
     let raffle_after = client.get_raffle();

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -7,17 +7,7 @@ use soroban_sdk::{
     Address, BytesN, Env,
 };
 
-mod mock_factory {
-    use soroban_sdk::{contractimpl, Address, Env};
-
-    pub struct MockFactory;
-
-    #[contractimpl]
-    impl MockFactory {
-        pub fn record_volume(_env: Env, _contract: Address, _token: Address, _amount: i128) {}
-        pub fn track_participant(_env: Env, _participant: Address) {}
-    }
-}
+use crate::mock_factory::MockFactory;
 
 #[test]
 fn test_oracle_fallback_with_ledger_delays() {
@@ -25,8 +15,7 @@ fn test_oracle_fallback_with_ledger_delays() {
     env.mock_all_auths();
 
     // 1. Setup factory, admin, creator
-    let factory_id = env.register_contract(None, mock_factory::MockFactory);
-    let factory = factory_id.address();
+    let factory = env.register(MockFactory, ());
     let admin = Address::generate(&env);
     let creator = Address::generate(&env);
     let oracle = Address::generate(&env);
@@ -37,8 +26,7 @@ fn test_oracle_fallback_with_ledger_delays() {
     let token_client = StellarAssetClient::new(&env, &payment_token);
     token_client.mint(&creator, &100_000_000);
 
-    #[allow(deprecated)]
-    let contract_id = env.register_contract(None, Contract);
+    let contract_id = env.register(Contract, ());
     let client = ContractClient::new(&env, &contract_id);
 
     // 2. Initialize Raffle with External Randomness

--- a/contracts/raffle/src/events.rs
+++ b/contracts/raffle/src/events.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{contractevent, Address, BytesN};
 use raffle_shared::AdminOp;
+use soroban_sdk::{contractevent, Address, BytesN};
 
 #[derive(Clone)]
 #[contractevent]

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -126,7 +126,7 @@ fn require_registered_raffle(env: &Env, raffle_address: &Address) -> Result<(), 
 }
 
 fn maybe_create_checkpoint(env: &Env, raffle_count: u32) {
-    if raffle_count == 0 || raffle_count % CHECKPOINT_INTERVAL != 0 {
+    if raffle_count == 0 || !raffle_count.is_multiple_of(CHECKPOINT_INTERVAL) {
         return;
     }
 
@@ -161,7 +161,7 @@ fn maybe_create_checkpoint(env: &Env, raffle_count: u32) {
         ledger_timestamp,
         aggregate_hash: aggregate_hash.into(),
     }
-    .publish(&env);
+    .publish(env);
 }
 
 #[contractimpl]

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -1,14 +1,14 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env, IntoVal,
-    Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env,
+    IntoVal, Symbol, Vec,
 };
 
 mod events;
 
 use raffle_shared::{
-    effective_limit, AdminOp, PageResultRaffles, PaginationParams, RaffleConfig, FairnessData,
+    effective_limit, AdminOp, FairnessData, PageResultRaffles, PaginationParams, RaffleConfig,
 };
 
 pub const TIMELOCK_DELAY_SECONDS: u64 = 172800; // 48 hours
@@ -160,7 +160,8 @@ fn maybe_create_checkpoint(env: &Env, raffle_count: u32) {
         raffle_count,
         ledger_timestamp,
         aggregate_hash: aggregate_hash.into(),
-    }.publish(&env);
+    }
+    .publish(&env);
 }
 
 #[contractimpl]
@@ -194,7 +195,8 @@ impl RaffleFactory {
             protocol_fee_bp,
             treasury,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -230,7 +232,8 @@ impl RaffleFactory {
             op,
             effective_timestamp,
             proposed_by: admin,
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(op_id)
     }
@@ -268,7 +271,8 @@ impl RaffleFactory {
             op: pending.op,
             executed_by: admin,
             executed_at: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -288,7 +292,8 @@ impl RaffleFactory {
             op_id,
             cancelled_by: admin,
             cancelled_at: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -338,7 +343,8 @@ impl RaffleFactory {
                     creator: creator.clone(),
                     unlock_timestamp,
                     timestamp: now,
-                }.publish(&env);
+                }
+                .publish(&env);
                 return Err(ContractError::RateLimitExceeded);
             }
 
@@ -380,7 +386,7 @@ impl RaffleFactory {
         let salt = env
             .crypto()
             .sha256(&(creator.clone(), final_config.description.clone()).to_xdr(&env));
-        
+
         #[cfg(not(test))]
         let raffle_address = env
             .deployer()
@@ -389,10 +395,16 @@ impl RaffleFactory {
 
         #[cfg(test)]
         let raffle_address = {
-            let mut count: u32 = env.storage().persistent().get(&DataKey::RaffleInstancesCount).unwrap_or(0);
+            let mut count: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RaffleInstancesCount)
+                .unwrap_or(0);
             count += 1;
-            env.storage().persistent().set(&DataKey::RaffleInstancesCount, &count);
-            
+            env.storage()
+                .persistent()
+                .set(&DataKey::RaffleInstancesCount, &count);
+
             let mut id = Address::generate(&env);
             for _ in 0..count {
                 id = Address::generate(&env);
@@ -531,7 +543,8 @@ impl RaffleFactory {
         events::ContractPaused {
             paused_by: admin,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -543,7 +556,8 @@ impl RaffleFactory {
         events::ContractUnpaused {
             unpaused_by: admin,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -575,7 +589,8 @@ impl RaffleFactory {
             current_admin: admin,
             proposed_admin: new_admin,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -597,7 +612,8 @@ impl RaffleFactory {
             old_admin,
             new_admin: pending,
             timestamp: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }
@@ -708,13 +724,13 @@ impl RaffleFactory {
             .persistent()
             .get(&DataKey::RaffleInstances)
             .unwrap_or_else(|| Vec::new(&env));
-        
+
         if raffle_id >= instances.len() {
             return Err(ContractError::InvalidRaffleId);
         }
 
         let raffle_address = instances.get(raffle_id).unwrap();
-        
+
         env.invoke_contract::<()>(
             &raffle_address,
             &Symbol::new(&env, "wipe_storage"),
@@ -734,9 +750,10 @@ impl RaffleFactory {
         events::RaffleCleanedUp {
             raffle_address,
             cleaned_by: admin,
-            finish_time: 0, 
+            finish_time: 0,
             cleaned_at: env.ledger().timestamp(),
-        }.publish(&env);
+        }
+        .publish(&env);
 
         Ok(())
     }

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -5,6 +5,9 @@ use soroban_sdk::{
     IntoVal, Symbol, Vec,
 };
 
+#[cfg(test)]
+use soroban_sdk::testutils::Address as _;
+
 mod events;
 
 use raffle_shared::{
@@ -762,7 +765,7 @@ impl RaffleFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::{Address as _, Events, Ledger};
+    use soroban_sdk::testutils::Address as _;
 
     fn setup_factory(env: &Env) -> (RaffleFactoryClient<'_>, Address, Address) {
         let admin = Address::generate(env);
@@ -780,7 +783,7 @@ mod tests {
     #[test]
     fn test_init_factory() {
         let env = Env::default();
-        let (client, admin, treasury) = setup_factory(&env);
+        let (client, admin, _treasury) = setup_factory(&env);
         assert_eq!(client.get_admin(), admin);
     }
 }

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -783,6 +783,7 @@ mod tests {
     #[test]
     fn test_init_factory() {
         let env = Env::default();
+        env.mock_all_auths();
         let (client, admin, _treasury) = setup_factory(&env);
         assert_eq!(client.get_admin(), admin);
     }

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -1,9 +1,12 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, xdr::ToXdr, Address, Bytes, BytesN, Env,
-    IntoVal, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, IntoVal,
+    Symbol, Vec,
 };
+
+#[cfg(not(test))]
+use soroban_sdk::xdr::ToXdr;
 
 #[cfg(test)]
 use soroban_sdk::testutils::Address as _;

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -356,12 +356,6 @@ impl RaffleFactory {
                 .set(&DataKey::LastCreationTime(creator.clone()), &now);
         }
 
-        let wasm_hash: BytesN<32> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::InstanceWasmHash)
-            .unwrap();
-
         let protocol_fee_bp: u32 = env
             .storage()
             .persistent()
@@ -386,15 +380,20 @@ impl RaffleFactory {
         let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
         let factory_address = env.current_contract_address();
 
-        let salt = env
-            .crypto()
-            .sha256(&(creator.clone(), final_config.description.clone()).to_xdr(&env));
-
         #[cfg(not(test))]
-        let raffle_address = env
-            .deployer()
-            .with_address(factory_address.clone(), salt)
-            .deploy_v2(wasm_hash, ());
+        let raffle_address = {
+            let wasm_hash: BytesN<32> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::InstanceWasmHash)
+                .unwrap();
+            let salt = env
+                .crypto()
+                .sha256(&(creator.clone(), final_config.description.clone()).to_xdr(&env));
+            env.deployer()
+                .with_address(factory_address.clone(), salt)
+                .deploy_v2(wasm_hash, ())
+        };
 
         #[cfg(test)]
         let raffle_address = {
@@ -765,8 +764,6 @@ impl RaffleFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Address as _;
-
     fn setup_factory(env: &Env) -> (RaffleFactoryClient<'_>, Address, Address) {
         let admin = Address::generate(env);
         let treasury = Address::generate(env);


### PR DESCRIPTION
## Summary
Add oracle address validation at init when ExternalRandomness source is selected. Prevents invalid oracle addresses from locking finalization forever.

## Related Issue
Closes #276

## Changes
In raffle-instance/src/lib.rs init():
- Reject oracle_address equal to the current contract (self-reference loop)
- Reject oracle_address when randomness source is not External (consistency check)
- Existing None check retained

Previously only oracle_address.is_none() was checked. A misconfigured oracle (current contract, zero-like, or set for wrong source) would pass init but cause finalization to stall indefinitely.
