### PR TITLE
.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,6 +16,7 @@ Welcome to the `tikka-contracts` development guide! This document covers setting
 
 ## 🏗 Build & Test
 
+
 ### Build the Contract
 To compile the Soroban contract into WebAssembly (`.wasm`):
 ```bash

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -104,10 +104,11 @@ pub enum Error {
     NotWinner = 14,
     ClaimTooEarly = 15,
     InvalidParameters = 21,
-    InvalidStatus = 22,
-    ContractPaused = 23,
-    InvalidStateTransition = 24,
-    RaffleExpired = 25,
+    InvalidQuantity = 22,
+    InvalidStatus = 23,
+    ContractPaused = 24,
+    InvalidStateTransition = 25,
+    RaffleExpired = 26,
     InsufficientTickets = 31,
     MultipleTicketsNotAllowed = 32,
     NoTicketsSold = 33,
@@ -325,6 +326,7 @@ impl Contract {
     }
 
     pub fn buy_tickets(env: Env, buyer: Address, quantity: u32) -> Result<u32, Error> {
+        require!(quantity > 0, Error::InvalidQuantity);
         let mut raffle = read_raffle(&env)?;
         buyer.require_auth();
         require_not_paused(&env)?;


### PR DESCRIPTION
PR Description
Summary
Added validation to [lib.rs](https://humble-waddle-6994vwx4r5g934rq5.github.dev/) so [buy_tickets](https://humble-waddle-6994vwx4r5g934rq5.github.dev/) now rejects [quantity == 0](https://humble-waddle-6994vwx4r5g934rq5.github.dev/) before performing auth, token, or storage operations.

Changes
Introduced [Error::InvalidQuantity](https://humble-waddle-6994vwx4r5g934rq5.github.dev/)
Added [require!(quantity > 0, Error::InvalidQuantity)](https://humble-waddle-6994vwx4r5g934rq5.github.dev/) as the first check in [buy_tickets](https://humble-waddle-6994vwx4r5g934rq5.github.dev/)
Why
Prevents no-op ticket purchase calls from consuming contract resources or altering state when [quantity](https://humble-waddle-6994vwx4r5g934rq5.github.dev/) is zero.

Notes
No functional behavior change for valid ticket purchases
Error handling now explicitly covers invalid ticket quantity inp
Closes #263 