### PR TITLE
fix: validate protocol_fee_bp at raffle init (#303)

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -240,6 +240,10 @@ impl Contract {
             return Err(Error::InvalidParameters);
         }
 
+        if config.protocol_fee_bp > 10000 {
+            return Err(Error::InvalidParameters);
+        }
+
         if config.randomness_source == RandomnessSource::External && config.oracle_address.is_none()
         {
             return Err(Error::InvalidParameters);


### PR DESCRIPTION
- Add validation that protocol_fee_bp <= 10000 at raffle creation time
- Previously only validated implicitly at claim time
- Prevents invalid config from being stored in the contract
close #303