### PR TITLE
fix(#240): bump instance TTL before token transfers

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -30,6 +30,20 @@ pub const MAX_DESCRIPTION_LENGTH: u32 = 1000;
 pub const MAX_TICKETS_LIMIT: u32 = 100_000;
 pub const MIN_TICKET_PRICE: i128 = 10_000;
 
+/// Minimum remaining ledgers before the instance TTL is considered "too close to expiry".
+/// If the TTL is below this threshold, extend_ttl will bump it up to INSTANCE_TTL_EXTEND_TO.
+pub const INSTANCE_TTL_THRESHOLD: u32 = 100_800; // ~7 days at 6s/ledger
+/// Target TTL (in ledgers) to extend the instance to on every state-changing call.
+pub const INSTANCE_TTL_EXTEND_TO: u32 = 518_400; // ~360 days at 6s/ledger
+
+/// Extends the contract instance TTL at the start of every state-changing entry point to
+/// prevent the instance from expiring mid-operation (issue #240).
+fn bump_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+}
+
 #[contract]
 pub struct Contract;
 
@@ -295,6 +309,7 @@ impl Contract {
     }
 
     pub fn deposit_prize(env: Env) -> Result<(), Error> {
+        bump_instance_ttl(&env);
         require_not_paused(&env)?;
         let mut raffle = read_raffle(&env)?;
         raffle.creator.require_auth();
@@ -325,6 +340,7 @@ impl Contract {
     }
 
     pub fn buy_tickets(env: Env, buyer: Address, quantity: u32) -> Result<u32, Error> {
+        bump_instance_ttl(&env);
         let mut raffle = read_raffle(&env)?;
         buyer.require_auth();
         require_not_paused(&env)?;
@@ -425,6 +441,7 @@ impl Contract {
     }
 
     pub fn finalize_raffle(env: Env) -> Result<(), Error> {
+        bump_instance_ttl(&env);
         let mut raffle = read_raffle(&env)?;
         raffle.creator.require_auth();
 
@@ -478,6 +495,7 @@ impl Contract {
         public_key: BytesN<32>,
         proof: BytesN<64>,
     ) -> Result<Address, Error> {
+        bump_instance_ttl(&env);
         let mut raffle = read_raffle(&env)?;
 
         let oracle = match &raffle.oracle_address {
@@ -511,6 +529,7 @@ impl Contract {
     }
 
     pub fn trigger_randomness_fallback(env: Env, caller: Address) -> Result<(), Error> {
+        bump_instance_ttl(&env);
         caller.require_auth();
         let raffle = read_raffle(&env)?;
 
@@ -547,6 +566,7 @@ impl Contract {
     }
 
     pub fn claim_prize(env: Env, winner: Address, tier_index: u32) -> Result<i128, Error> {
+        bump_instance_ttl(&env);
         winner.require_auth();
         acquire_guard(&env)?;
         let mut raffle = read_raffle(&env)?;
@@ -611,6 +631,7 @@ impl Contract {
     }
 
     pub fn cancel_raffle(env: Env, reason: CancelReason) -> Result<(), Error> {
+        bump_instance_ttl(&env);
         let mut raffle = read_raffle(&env)?;
         
         if reason == CancelReason::AdminCancelled {
@@ -640,6 +661,7 @@ impl Contract {
     }
 
     pub fn refund_prize(env: Env) -> Result<(), Error> {
+        bump_instance_ttl(&env);
         let mut raffle = read_raffle(&env)?;
         raffle.creator.require_auth();
 
@@ -668,6 +690,7 @@ impl Contract {
     }
 
     pub fn refund_ticket(env: Env, ticket_id: u32) -> Result<i128, Error> {
+        bump_instance_ttl(&env);
         acquire_guard(&env)?;
         let raffle = read_raffle(&env)?;
 


### PR DESCRIPTION
## Summary

Fixes #240

Without an instance TTL extension, the contract's instance storage can expire between the auth check and the token transfer call. This leaves funds in limbo — state has already been mutated (e.g. `tickets_sold` incremented, `prize_deposited` cleared) but the on-chain contract instance is no longer accessible.

## Root Cause

The `raffle-instance` contract never called `extend_ttl` on its instance storage. On Stellar/Soroban, instance storage has a TTL counted in ledgers. If a raffle runs long enough to approach that expiry, any state-changing call can fail mid-execution after auth but before the token transfer completes.

## Changes

Added a `bump_instance_ttl()` helper in `contracts/raffle-instance/src/lib.rs`:

`ust
pub const INSTANCE_TTL_THRESHOLD: u32 = 100_800; // ~7 days at 6s/ledger
pub const INSTANCE_TTL_EXTEND_TO: u32 = 518_400; // ~360 days at 6s/ledger

fn bump_instance_ttl(env: &Env) {
    env.storage()
        .instance()
        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
}
`

Called as the **first statement** in every state-changing entry point:

| Entry point | Risk |
|---|---|
| `buy_tickets` | buyer → contract transfer + fee → treasury |
| `deposit_prize` | creator → contract transfer |
| `finalize_raffle` | triggers irreversible draw |
| `provide_randomness` | triggers irreversible draw |
| `trigger_randomness_fallback` | triggers irreversible draw |
| `claim_prize` | contract → winner + fee → treasury |
| `cancel_raffle` | mutates raffle status |
| `refund_prize` | contract → creator transfer |
| `refund_ticket` | contract → buyer transfer |

`extend_ttl` is a no-op when the TTL is already above the threshold, so there is zero overhead on healthy contracts.