### PR TITLE
Add TreasuryNotSet error code and update event imports

### DIFF
--- a/contracts/raffle/src/events.rs
+++ b/contracts/raffle/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, Address, BytesN, u128};
+use soroban_sdk::{contractevent, Address, BytesN};
 use raffle_shared::AdminOp;
 
 #[derive(Clone)]

--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -79,6 +79,7 @@ pub enum ContractError {
     TimelockNotElapsed = 15,
     InvalidRaffleId = 16,
     RaffleNotEligible = 17,
+    TreasuryNotSet = 18,
 }
 
 #[contract]
@@ -333,7 +334,11 @@ impl RaffleFactory {
             .persistent()
             .get(&DataKey::ProtocolFeeBP)
             .unwrap_or(0);
-        let treasury: Address = env.storage().persistent().get(&DataKey::Treasury).unwrap();
+        let treasury: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Treasury)
+            .ok_or(ContractError::TreasuryNotSet)?;
 
         let mut instances: Vec<Address> = env
             .storage()

--- a/docs/ERRORS.md
+++ b/docs/ERRORS.md
@@ -77,6 +77,7 @@ The factory contract (`RaffleFactory`) manages raffle creation. All error codes 
 | 3    | `ContractPaused`     | Factory is paused              | "Factory is temporarily paused" |
 | 4    | `InvalidParameters`  | Invalid parameters provided    | "Invalid parameters provided"   |
 | 5    | `RaffleNotFound`     | Raffle instance not found      | "Raffle not found"              |
+| 18   | `TreasuryNotSet`     | Treasury address is not configured | "Treasury address is not set" |
 
 ### Admin Errors (11-20)
 


### PR DESCRIPTION
closed #300 

Reviewing the exact file changes so the PR docs are accurate and complete.

Ran terminal command:  git diff -- contracts/raffle/src/lib.rs contracts/raffle/src/events.rs docs/ERRORS.md

No diff output found; checking repository status to confirm the changed files and branch state.

Ran terminal command:  git status --short

Confirming the final code contents so the PR description is exact.

Read [](file:///home/gift/tikka-contracts/contracts/raffle/src/lib.rs#80-80), lines 80 to 120

Read [](file:///home/gift/tikka-contracts/contracts/raffle/src/lib.rs#160-160), lines 160 to 210

Read [](file:///home/gift/tikka-contracts/contracts/raffle/src/lib.rs#230-230), lines 230 to 290

Read [](file:///home/gift/tikka-contracts/contracts/raffle/src/lib.rs#290-290), lines 290 to 330

Read [](file:///home/gift/tikka-contracts/contracts/raffle/src/lib.rs#330-330), lines 330 to 360

Read [](file:///home/gift/tikka-contracts/contracts/raffle/src/events.rs#1-1), lines 1 to 10

Read [](file:///home/gift/tikka-contracts/docs/ERRORS.md#70-70), lines 70 to 90

## PR Documentation

### Title
Fix factory treasury lookup panic when treasury key is missing

### Summary
This change hardens `RaffleFactory::create_raffle` by replacing a panic-causing `unwrap()` on the `Treasury` storage key with a proper error return: `ContractError::TreasuryNotSet`.

### What changed
- lib.rs
  - Added `ContractError::TreasuryNotSet = 18`
  - Replaced `env.storage().persistent().get(&DataKey::Treasury).unwrap()`
    with `ok_or(ContractError::TreasuryNotSet)?` in `create_raffle()`
- ERRORS.md
  - Documented `TreasuryNotSet` under factory errors
- events.rs
  - Fixed invalid import by removing `u128` from `soroban_sdk` imports

### Why
- Prevents the factory contract from panicking if the `Treasury` key is deleted or missing
- Provides a clear, recoverable on-chain error instead of a contract panic
- Ensures the `raffle-factory` crate compiles cleanly

### Testing
- Verified with:
  - `cargo check -p raffle-factory --manifest-path contracts/raffle/Cargo.toml`

### Notes
- This addresses the issue where `create_raffle` would fail catastrophically when treasury storage was absent.