### PR TITLE
fix(refund): ensure atomic rollback in refund_ticket to prevent state…

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -672,6 +672,7 @@ impl Contract {
         let raffle = read_raffle(&env)?;
 
         if raffle.status != RaffleStatus::Cancelled && raffle.status != RaffleStatus::Failed {
+            release_guard(&env);
             return Err(Error::InvalidStatus);
         }
 
@@ -681,13 +682,27 @@ impl Contract {
         // Check if already refunded
         let refund_key = (DataKey::Ticket(ticket_id), Symbol::new(&env, "refunded"));
         if env.storage().persistent().has(&refund_key) {
+            release_guard(&env);
             return Err(Error::InvalidStatus); // Already refunded
         }
 
-        env.storage().persistent().set(&refund_key, &true);
-
+        // Perform transfer FIRST before marking as refunded
+        // This ensures atomicity - if transfer fails, state remains unchanged
         let token_client = token::Client::new(&env, &raffle.payment_token);
-        token_client.transfer(&env.current_contract_address(), &ticket.owner, &raffle.ticket_price);
+        let transfer_result = token_client.try_transfer(
+            &env.current_contract_address(),
+            &ticket.owner,
+            &raffle.ticket_price
+        );
+
+        // Only mark as refunded if transfer succeeded
+        if transfer_result.is_err() {
+            release_guard(&env);
+            return Err(Error::TokenTransferFailed);
+        }
+
+        // Mark ticket as refunded AFTER successful transfer
+        env.storage().persistent().set(&refund_key, &true);
 
         crate::events::TicketRefunded {
             buyer: ticket.owner,


### PR DESCRIPTION
… corruption

close #248

## Problem
The refund_ticket function had a critical vulnerability where it marked tickets as refunded in storage BEFORE performing the token transfer. If the transfer failed, the ticket would be permanently marked as refunded but the user would never receive their funds, leading to state corruption.

## Solution
1. Reordered operations to perform the token transfer FIRST
2. Changed from transfer() to try_transfer() for proper error handling
3. Only mark ticket as refunded AFTER successful transfer
4. Added proper error handling - if transfer fails, state remains unchanged
5. Ensured reentrancy guard is properly released on all error paths

## Changes
- Moved token transfer before state mutation
- Used try_transfer() instead of transfer() for safe error handling
- Added early guard release on error paths to prevent deadlocks
- Added comprehensive comments explaining the atomic behavior

This ensures atomicity: if the transfer fails, the storage state remains unchanged and the user can retry the refund.