### PR TITLE
Added the init-time invariant

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -118,6 +118,7 @@ pub enum Error {
     NotInitialized = 43,
     Reentrancy = 44,
     TokenTransferFailed = 45,
+    InvalidTicketRange = 46,
 }
 
 fn read_raffle(env: &Env) -> Result<Raffle, Error> {
@@ -221,6 +222,9 @@ impl Contract {
         }
         if config.max_tickets == 0 || config.max_tickets > MAX_TICKETS_LIMIT {
             return Err(Error::InvalidParameters);
+        }
+        if config.max_tickets < config.min_tickets {
+            return Err(Error::InvalidTicketRange);
         }
 
         if config.ticket_price < MIN_TICKET_PRICE {


### PR DESCRIPTION
Closes #279 
Added the init-time invariant in contracts/raffle-instance/src/lib.rs (line 204): init now rejects configs where max_tickets < min_tickets, and I introduced Error::InvalidTicketRange in the local error enum at contracts/raffle-instance/src/lib.rs (line 91) so the failure is explicit.
I also ran cargo check -p raffle-instance. That did not pass, but the failures are pre-existing and unrelated to this patch: the contract currently has Soroban serialization/type errors for Raffle and FairnessMetadata, plus an existing usize/u32 comparison issue around line 562. If you want, I can take a pass at cleaning those compile errors up next.