### PR TITLE
Add caller field to DrawTriggered event for draw initiator auditability

### DIFF
--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -50,7 +50,7 @@ pub struct TicketPurchased {
 #[derive(Clone)]
 #[contractevent]
 pub struct DrawTriggered {
-    pub triggered_by: Address,
+    pub caller: Address,
     pub total_tickets_sold: u32,
     pub timestamp: u64,
 }

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -453,6 +453,8 @@ impl Contract {
             return Ok(());
         }
 
+        let caller = env.invoker();
+
         if raffle.randomness_source == RandomnessSource::External {
             let already: bool = env.storage().instance().get(&DataKey::RandomnessRequested).unwrap_or(false);
             if already {
@@ -461,12 +463,24 @@ impl Contract {
             env.storage().instance().set(&DataKey::RandomnessRequested, &true);
             env.storage().instance().set(&DataKey::RandomnessRequestLedger, &env.ledger().sequence());
 
+            DrawTriggered {
+                caller: caller.clone(),
+                total_tickets_sold: raffle.tickets_sold,
+                timestamp: now,
+            }.publish(&env);
+
             RandomnessRequested {
                 oracle: raffle.oracle_address.clone().unwrap_or(env.current_contract_address()),
                 timestamp: now,
             }.publish(&env);
             return Ok(());
         }
+
+        DrawTriggered {
+            caller: caller.clone(),
+            total_tickets_sold: raffle.tickets_sold,
+            timestamp: now,
+        }.publish(&env);
 
         let seed = build_internal_seed_u64(&env);
         self::do_finalize_with_seed(&env, raffle, seed, RandomnessType::Prng)

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -69,7 +69,7 @@ Emitted when the draw process is initiated.
 **Topic:** `("tikka", "draw_triggered")`
 
 **Fields:**
-- `triggered_by: Address` - Address that triggered the draw
+- `caller: Address` - Address that initiated the draw
 - `total_tickets_sold: u32` - Total number of tickets sold at draw time
 - `timestamp: u64` - Unix timestamp when draw was triggered
 


### PR DESCRIPTION
Closes #271 

## PR Description

### Summary
Added `caller: Address` to the `DrawTriggered` event so the entity initiating a raffle draw is recorded on-chain, even when finalization is delegated through a factory or automation contract.

### What changed
- Updated events.rs
  - `DrawTriggered` now includes `caller: Address`
- Updated lib.rs
  - `finalize_raffle()` now emits `DrawTriggered` with `caller` from `env.invoker()`
- Updated EVENTS.md
  - Documented `caller` field for `draw_triggered`

### Why
This makes draw initiation auditable and preserves the on-chain provenance of who triggered finalization.
