### PR TITLE
fix: avoid panic when raffle instances missing

### DIFF
--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -336,10 +336,10 @@ impl RaffleFactory {
         let treasury: Address = env.storage().persistent().get(&DataKey::Treasury).unwrap();
 
         let mut instances: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::RaffleInstances)
-            .unwrap();
+    .storage()
+    .persistent()
+    .get(&DataKey::RaffleInstances)
+    .unwrap_or_else(|| Vec::new(&env));
 
         let mut final_config = config;
         final_config.protocol_fee_bp = protocol_fee_bp;


### PR DESCRIPTION
Closes #297 