### PR TITLE
Replace end_time==0 sentinel with explicit no_deadline flag

### DIFF
--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -38,6 +38,7 @@ pub struct Raffle {
     pub creator: Address,
     pub description: String,
     pub end_time: u64,
+    pub no_deadline: bool,
     pub max_tickets: u32,
     pub min_tickets: u32,
     pub allow_multiple: bool,
@@ -216,7 +217,10 @@ impl Contract {
         }
 
         let now = env.ledger().timestamp();
-        if config.end_time <= now && config.end_time != 0 {
+        if config.no_deadline && config.end_time != 0 {
+            return Err(Error::InvalidParameters);
+        }
+        if !config.no_deadline && config.end_time <= now {
             return Err(Error::InvalidParameters);
         }
         if config.max_tickets == 0 || config.max_tickets > MAX_TICKETS_LIMIT {
@@ -253,6 +257,7 @@ impl Contract {
             creator: creator.clone(),
             description: config.description.clone(),
             end_time: config.end_time,
+            no_deadline: config.no_deadline,
             max_tickets: config.max_tickets,
             min_tickets: config.min_tickets,
             allow_multiple: config.allow_multiple,
@@ -335,7 +340,7 @@ impl Contract {
         if !raffle.prize_deposited {
             return Err(Error::InvalidStateTransition);
         }
-        if raffle.end_time != 0 && env.ledger().timestamp() > raffle.end_time {
+        if !raffle.no_deadline && env.ledger().timestamp() > raffle.end_time {
             return Err(Error::RaffleExpired);
         }
 
@@ -433,7 +438,7 @@ impl Contract {
         }
 
         let now = env.ledger().timestamp();
-        let time_ended = raffle.end_time != 0 && now >= raffle.end_time;
+        let time_ended = !raffle.no_deadline && now >= raffle.end_time;
         let tickets_full = raffle.tickets_sold >= raffle.max_tickets;
 
         if raffle.status == RaffleStatus::Active && !time_ended && !tickets_full {

--- a/contracts/raffle-shared/src/lib.rs
+++ b/contracts/raffle-shared/src/lib.rs
@@ -43,6 +43,7 @@ pub enum RandomnessType {
 pub struct RaffleConfig {
     pub description: String,
     pub end_time: u64,
+    pub no_deadline: bool,
     pub max_tickets: u32,
     pub min_tickets: u32,
     pub allow_multiple: bool,


### PR DESCRIPTION
- Add no_deadline: bool to RaffleConfig and Raffle struct
- init: reject end_time==0 unless no_deadline=true; reject no_deadline=true with non-zero end_time
- buy_tickets, finalize_raffle: check !no_deadline instead of end_time != 0
close #227 