### PR TITLE
fix(raffle): prevent total volume overflow in record_volume

### DIFF
--- a/contracts/raffle/src/lib.rs
+++ b/contracts/raffle/src/lib.rs
@@ -79,6 +79,7 @@ pub enum ContractError {
     TimelockNotElapsed = 15,
     InvalidRaffleId = 16,
     RaffleNotEligible = 17,
+    ArithmeticOverflow = 18,
 }
 
 #[contract]
@@ -436,12 +437,14 @@ impl RaffleFactory {
     }
 
     pub fn record_volume(env: Env, asset: Address, amount: i128) -> Result<(), ContractError> {
-        let mut total_volume: i128 = env
+        let total_volume: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::TotalVolumePerAsset(asset.clone()))
             .unwrap_or(0);
-        total_volume += amount;
+        let total_volume = total_volume
+            .checked_add(amount)
+            .ok_or(ContractError::ArithmeticOverflow)?;
         env.storage()
             .persistent()
             .set(&DataKey::TotalVolumePerAsset(asset), &total_volume);
@@ -729,5 +732,18 @@ mod tests {
         let env = Env::default();
         let (client, admin, treasury) = setup_factory(&env);
         assert_eq!(client.get_admin(), admin);
+    }
+
+    #[test]
+    fn test_record_volume_overflow() {
+        let env = Env::default();
+        let (client, _admin, _treasury) = setup_factory(&env);
+        let asset = Address::generate(&env);
+
+        assert_eq!(client.get_total_volume(&asset), 0);
+        assert_eq!(client.record_volume(&asset, &i128::MAX), Ok(()));
+        assert_eq!(client.get_total_volume(&asset), i128::MAX);
+        assert_eq!(client.record_volume(&asset, &1), Err(ContractError::ArithmeticOverflow));
+        assert_eq!(client.get_total_volume(&asset), i128::MAX);
     }
 }


### PR DESCRIPTION
Close #270 




## Pull Request Description

### Summary
Fixes a silent overflow bug in the raffle factory contract where `record_volume` used unchecked addition for `total_volume`. This could corrupt volume analytics and fee calculations when large amounts were accumulated.

### Changes
- Updated lib.rs
  - `record_volume` now uses `checked_add(amount)`
  - returns `ContractError::ArithmeticOverflow` on overflow
- Added regression test `test_record_volume_overflow`

### Verification
Run:

```bash
cargo test -p raffle
```
