### PR TITLE
fix(raffle-instance): add finalized-state guard to withdraw_fees

### DIFF
--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -123,6 +123,15 @@ pub struct PrizeClaimed {
 
 #[derive(Clone)]
 #[contractevent]
+pub struct FeesWithdrawn {
+    pub recipient: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub timestamp: u64,
+}
+
+#[derive(Clone)]
+#[contractevent]
 pub struct RandomnessFallbackTriggered {
     pub triggered_by: Address,
     pub seed_used: u64,

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -18,8 +18,8 @@ use self::randomness::{
 };
 
 use crate::events::{
-    DrawTriggered, PrizeClaimed, PrizeDeposited, PrizeRefunded, RaffleCancelled, RaffleCreated,
-    RaffleFinalized, RaffleStatusChanged, RandomnessReceived,
+    DrawTriggered, FeesWithdrawn, PrizeClaimed, PrizeDeposited, PrizeRefunded, RaffleCancelled,
+    RaffleCreated, RaffleFinalized, RaffleStatusChanged, RandomnessReceived,
     RandomnessRequested, TicketPurchased,
     WinnerDrawn, RandomnessFallbackTriggered,
     ContractPaused, ContractUnpaused,
@@ -633,6 +633,36 @@ impl Contract {
 
         release_guard(&env);
         Ok(net_amount)
+    }
+
+    pub fn withdraw_fees(
+        env: Env,
+        recipient: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
+        admin.require_auth();
+
+        let raffle = read_raffle(&env)?;
+        if raffle.status != RaffleStatus::Finalized {
+            return Err(Error::InvalidStatus);
+        }
+
+        if amount <= 0 {
+            return Err(Error::InvalidParameters);
+        }
+
+        let token_client = token::Client::new(&env, &raffle.payment_token);
+        token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+
+        FeesWithdrawn {
+            recipient,
+            amount,
+            token: raffle.payment_token.clone(),
+            timestamp: env.ledger().timestamp(),
+        }.publish(&env);
+
+        Ok(())
     }
 
     pub fn cancel_raffle(env: Env, reason: CancelReason) -> Result<(), Error> {


### PR DESCRIPTION
Close #268 

## PR Description

**Title:** Fix `withdraw_fees` to require `RaffleStatus::Finalized`

### Summary
- Added a new admin-only `withdraw_fees` function in lib.rs
- Enforced a `RaffleStatus::Finalized` guard so fees cannot be withdrawn while the raffle is still active or drawing
- Added `FeesWithdrawn` event in events.rs for transparency

### Files changed
- lib.rs
- events.rs

### Why
Without this guard, an admin could drain accumulated fees before the raffle completed, leaving the contract underfunded for final prize payouts.

### Testing
1. Ensure the Rust toolchain is installed
2. Run:
   - `cargo build -p raffle-instance`
   - `cargo test -p raffle-instance`

---
