### PR TITLE
feat(raffle-instance): add time-gated emergency_withdraw to recover s…

### DIFF
--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -152,3 +152,14 @@ pub struct ContractUnpaused {
     pub unpaused_by: Address,
     pub timestamp: u64,
 }
+
+
+#[derive(Clone)]
+#[contractevent]
+pub struct EmergencyWithdrawn {
+    pub withdrawn_by: Address,
+    pub to: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub timestamp: u64,
+}

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -23,6 +23,7 @@ use crate::events::{
     RandomnessRequested, TicketPurchased,
     WinnerDrawn, RandomnessFallbackTriggered,
     ContractPaused, ContractUnpaused,
+    EmergencyWithdrawn,
 };
 
 const ORACLE_TIMEOUT_LEDGERS: u32 = 200;
@@ -32,6 +33,8 @@ pub const MIN_TICKET_PRICE: i128 = 10_000;
 /// Default and bounds for the claim lockup delay (#259).
 pub const DEFAULT_CLAIM_LOCKUP_SECONDS: u64 = 3_600;
 pub const MAX_CLAIM_LOCKUP_SECONDS: u64 = 604_800; // 7 days
+/// Emergency withdraw delay (seconds). Set to 90 days.
+pub const EMERGENCY_WITHDRAW_DELAY_SECONDS: u64 = 90 * 24 * 3600; // 7776000
 
 #[contract]
 pub struct Contract;
@@ -124,6 +127,7 @@ pub enum Error {
     NotInitialized = 43,
     Reentrancy = 44,
     TokenTransferFailed = 45,
+    EmergencyTooEarly = 50,
 }
 
 fn read_raffle(env: &Env) -> Result<Raffle, Error> {
@@ -684,6 +688,60 @@ impl Contract {
 
         PrizeRefunded {
             creator: raffle.creator.clone(),
+            amount: raffle.prize_amount,
+            token: raffle.payment_token.clone(),
+            timestamp: env.ledger().timestamp(),
+        }.publish(&env);
+
+        Ok(())
+    }
+
+    pub fn emergency_withdraw(env: Env, caller: Address) -> Result<(), Error> {
+        caller.require_auth();
+        let mut raffle = read_raffle(&env)?;
+
+        if !raffle.prize_deposited {
+            return Err(Error::PrizeNotDeposited);
+        }
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
+        if caller != raffle.creator && caller != admin {
+            return Err(Error::NotAuthorized);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Allow emergency withdraw only after a long timeout.
+        match raffle.status {
+            RaffleStatus::Finalized => {
+                if let Some(finalized_at) = raffle.finalized_at {
+                    if now < finalized_at + EMERGENCY_WITHDRAW_DELAY_SECONDS {
+                        return Err(Error::EmergencyTooEarly);
+                    }
+                } else {
+                    return Err(Error::EmergencyTooEarly);
+                }
+            }
+            RaffleStatus::Drawing => {
+                // If raffle had an explicit end time, allow after end_time + delay
+                if raffle.end_time == 0 || now < raffle.end_time + EMERGENCY_WITHDRAW_DELAY_SECONDS {
+                    return Err(Error::EmergencyTooEarly);
+                }
+            }
+            _ => return Err(Error::InvalidStatus),
+        }
+
+        // Mark prize as withdrawn and transfer back to creator
+        raffle.prize_deposited = false;
+        raffle.status = RaffleStatus::Cancelled;
+        write_raffle(&env, &raffle);
+
+        let token_client = token::Client::new(&env, &raffle.payment_token);
+        token_client.transfer(&env.current_contract_address(), &raffle.creator, &raffle.prize_amount);
+
+        EmergencyWithdrawn {
+            withdrawn_by: caller,
+            to: raffle.creator.clone(),
             amount: raffle.prize_amount,
             token: raffle.payment_token.clone(),
             timestamp: env.ledger().timestamp(),


### PR DESCRIPTION
Close #285 

**Pull Request (PR) — Title**
- feat(raffle-instance): add time-gated `emergency_withdraw` to recover stuck prizes

**Pull Request — Description**
- **Summary:** Adds a time-gated emergency withdrawal to the raffle instance contract to allow recovering prize funds that would otherwise be permanently stuck. Implemented a 90-day delay before the emergency path can be used, an event, and an error code.
- **Files changed:** lib.rs, events.rs
- **What I changed:**  
  - **events.rs:** Added `EmergencyWithdrawn` event (emitted when emergency withdrawal occurs).  
  - **lib.rs:** Added `EMERGENCY_WITHDRAW_DELAY_SECONDS` (90 days), `Error::EmergencyTooEarly`, imported the new event, and implemented `pub fn emergency_withdraw(env: Env, caller: Address) -> Result<(), Error>` that:
    - Requires `caller` auth and must be either the raffle `creator` or `admin`.
    - Only allows withdrawal when `prize_deposited == true` and after the configured long timeout:
      - If `Finalized`: require `finalized_at + EMERGENCY_WITHDRAW_DELAY_SECONDS <= now`.
      - If `Drawing` with an `end_time`: require `end_time + EMERGENCY_WITHDRAW_DELAY_SECONDS <= now`.
    - Marks `prize_deposited = false`, sets `status = Cancelled`, transfers the prize back to the raffle `creator`, and emits `EmergencyWithdrawn`.
- **Rationale:** Addresses the documented issue that stuck prize funds are currently unrecoverable. The long, time-gated window preserves normal claimant/refund flows while providing a last-resort recovery after ample time.
- **Behavior / Constraints:**  
  - Callable only by raffle `creator` or contract `admin`.  
  - Only usable after a long delay (default: 90 days).  
  - Transfers prize back to `creator` and sets raffle `status` to `Cancelled`.  
  - Emits `EmergencyWithdrawn(withdrawn_by, to, amount, token, timestamp)`.
- **Backward compatibility:** Non-breaking — adds a new entrypoint and event; no existing flows changed except that emergency withdraw will update status and prize flag when used.
- **Security considerations:**  
  - Long delay reduces accidental/abusive use.  
  - Only `creator` and `admin` permitted and `require_auth()` is enforced.  
  - Token transfer uses `token::Client::transfer`. Consider adding reentrancy guard if needed for this entrypoint (current implementation follows existing refund patterns).  
  - Review required for governance policy (who may act as `admin`) and the chosen timeout length.
- **Testing / Verification steps:** (run locally)
  - Build & test:
    ```
    cargo build -p raffle-instance
    cargo test -p raffle-instance
    ```
  - Recommended unit tests to add:
    - Emergency withdraw attempt before timeout → expect `Error::EmergencyTooEarly`.
    - Emergency withdraw by non-authorized caller → expect `Error::NotAuthorized`.
    - Emergency withdraw after timeout by creator/admin → state changes: `prize_deposited == false`, `status == Cancelled`; `EmergencyWithdrawn` event emitted; contract token balance decreases and creator receives `prize_amount`.
    - Ensure normal claim/refund flows still work unchanged.

