### PR TITLE
feat: #232 Add RaffleFailed event to distinguish failures from cancel…

### DIFF
--- a/contracts/raffle-instance/src/events.rs
+++ b/contracts/raffle-instance/src/events.rs
@@ -1,4 +1,4 @@
-use raffle_shared::{CancelReason, RandomnessSource, RandomnessType};
+use raffle_shared::{CancelReason, FailureReason, RandomnessSource, RandomnessType};
 use soroban_sdk::{contractevent, Address, BytesN, String, Vec};
 
 #[derive(Clone)]
@@ -111,6 +111,15 @@ pub struct RaffleCancelled {
     pub reason: CancelReason,
     pub tickets_sold: u32,
     pub prize_refunded: bool,
+    pub timestamp: u64,
+}
+
+#[derive(Clone)]
+#[contractevent]
+pub struct RaffleFailed {
+    pub creator: Address,
+    pub reason: FailureReason,
+    pub tickets_sold: u32,
     pub timestamp: u64,
 }
 

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -11,7 +11,7 @@ mod events;
 mod randomness;
 
 use raffle_shared::{
-    CancelReason, FairnessData, RaffleConfig, RaffleStatus, RandomnessSource, RandomnessType,
+    CancelReason, FailureReason, FairnessData, RaffleConfig, RaffleStatus, RandomnessSource, RandomnessType,
     Ticket,
 };
 
@@ -20,7 +20,7 @@ use self::randomness::{OracleSeedWinnerSelection, WinnerSelectionStrategy};
 use crate::events::{
     ContractPaused, ContractUnpaused, DrawTriggered, EmergencyWithdrawn, FeesWithdrawn,
     OracleAddressUpdated, PrizeClaimed, PrizeDeposited, PrizeRefunded, ProtocolFeeUpdated,
-    RaffleCancelled, RaffleCreated, RaffleFinalized, RaffleStatusChanged,
+    RaffleCancelled, RaffleCreated, RaffleFinalized, RaffleFailed, RaffleStatusChanged,
     RandomnessFallbackTriggered, RandomnessReceived, RandomnessRequested, TicketPurchased,
     TicketRefunded, TokensRescued, WinnerDrawn,
 };
@@ -642,9 +642,16 @@ impl Contract {
             raffle.status = RaffleStatus::Failed;
             write_raffle(&env, &raffle);
 
-            RaffleStatusChanged {
-                old_status,
-                new_status: RaffleStatus::Failed,
+            let failure_reason = if raffle.tickets_sold == 0 {
+                FailureReason::ZeroTicketsSold
+            } else {
+                FailureReason::MinTicketsNotMet
+            };
+
+            RaffleFailed {
+                creator: raffle.creator.clone(),
+                reason: failure_reason,
+                tickets_sold: raffle.tickets_sold,
                 timestamp: now,
             }
             .publish(&env);

--- a/contracts/raffle-shared/src/lib.rs
+++ b/contracts/raffle-shared/src/lib.rs
@@ -30,6 +30,13 @@ pub enum CancelReason {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[contracttype]
+pub enum FailureReason {
+    ZeroTicketsSold = 0,
+    MinTicketsNotMet = 1,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[contracttype]
 pub enum RandomnessSource {
     Internal = 0,
     External = 1,


### PR DESCRIPTION
…lations

- Add FailureReason enum in raffle-shared with ZeroTicketsSold and MinTicketsNotMet variants
- Add RaffleFailed event in raffle-instance with creator, reason, tickets_sold, and timestamp fields
- Replace generic RaffleStatusChanged event with dedicated RaffleFailed event when raffle fails due to insufficient tickets
- Allows off-chain indexers and UIs to distinguish raffle failures from explicit cancellations

Fixes #232


Closes #232