### PR TITLE
fix: enforce minimum ledger delay for raffle randomness fulfillment

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Overview
+
+## Front-Running Mitigation: Randomness Fulfillment Delay
+
+### Attack Vector
+The raffle contract's randomness fulfillment mechanism (`provide_randomness`) was vulnerable to front-running and manipulation attacks. In the original implementation, an oracle could submit randomness immediately after a raffle transitioned to `Drawing`, potentially allowing an attacker to:
+1. Observe the pending raffle finalization
+2. Manipulate oracle behavior to favor specific outcomes
+3. Execute malicious transactions in the same block
+
+### Mitigation Implemented
+To address this vulnerability, we've implemented a minimum ledger delay between randomness request and fulfillment:
+
+- A constant `RANDOMNESS_MIN_DELAY_LEDGERS = 10` is enforced
+- When randomness is requested (during the Drawing phase transition), the current ledger sequence is stored under `DataKey::RandomnessRequestLedger`
+- In `provide_randomness`, we check that the current ledger sequence is at least 10 ledgers higher than the request ledger
+- If fulfillment is attempted too early, the transaction is rejected with `Error::RandomnessTooEarly`
+
+This delay ensures there's sufficient time for:
+- The market and participants to stabilize
+- No same-block manipulation
+- A clear window between request and fulfillment
+
+### Other Security Considerations
+- **Drawing Lock**: Exclusive lock to prevent concurrent state transitions
+- **Oracle Timeout**: Fallback mechanism if oracle doesn't respond within 200 ledgers
+- **Reentrancy Guard**: Prevents reentrant attacks

--- a/contracts/raffle-instance/src/lib.rs
+++ b/contracts/raffle-instance/src/lib.rs
@@ -27,6 +27,7 @@ use crate::events::{
 };
 
 const ORACLE_TIMEOUT_LEDGERS: u32 = 200;
+const RANDOMNESS_MIN_DELAY_LEDGERS: u32 = 10;
 pub const MAX_DESCRIPTION_LENGTH: u32 = 1000;
 pub const MAX_TICKETS_LIMIT: u32 = 100_000;
 pub const MAX_PRIZES: u32 = 100;
@@ -175,6 +176,7 @@ pub enum Error {
     DrawingAlreadyComplete = 61,
     InvalidEndTime = 62,
     InvalidAdminAddress = 63,
+    RandomnessTooEarly = 64,
 }
 
 fn read_raffle(env: &Env) -> Result<Raffle, Error> {
@@ -1052,6 +1054,16 @@ impl Contract {
             .ok_or(Error::NoRandomnessRequest)?;
         if stored_request_id != request_id {
             return Err(Error::InvalidParameters);
+        }
+
+        // Verify minimum delay has passed
+        let request_ledger: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::RandomnessRequestLedger)
+            .unwrap_or(0);
+        if env.ledger().sequence() < request_ledger + RANDOMNESS_MIN_DELAY_LEDGERS {
+            return Err(Error::RandomnessTooEarly);
         }
 
         let message = Bytes::from_array(&env, &random_seed.to_be_bytes());

--- a/contracts/raffle-instance/src/test.rs
+++ b/contracts/raffle-instance/src/test.rs
@@ -537,3 +537,165 @@ fn test_allow_multiple_false_single_ticket_per_buyer() {
         });
     assert_eq!(buyer_b_count, 1);
 }
+
+#[test]
+fn test_provide_randomness_fails_too_early() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // 1. Setup factory, admin, creator
+    let factory = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let payment_token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = StellarAssetClient::new(&env, &payment_token);
+    token_client.mint(&creator, &100_000_000);
+
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    // 2. Initialize Raffle with External Randomness
+    let config = RaffleConfig {
+        description: String::from_str(&env, "Test Raffle Early Randomness"),
+        end_time: 0,
+        no_deadline: true,
+        max_tickets: 10,
+        max_tickets_per_tx: 10,
+        min_tickets: 1,
+        allow_multiple: true,
+        ticket_price: 10_000,
+        payment_token: payment_token.clone(),
+        prize_amount: 10_000,
+        prizes: soroban_sdk::vec![&env, 10000],
+        randomness_source: RandomnessSource::External,
+        oracle_address: Some(oracle.clone()),
+        protocol_fee_bp: 0,
+        treasury_address: None,
+        swap_router: None,
+        tikka_token: None,
+        metadata_hash: BytesN::from_array(&env, &[1; 32]),
+        claim_lockup_seconds: 0,
+        swap_deadline_seconds: 0,
+    };
+
+    client.init(&factory, &admin, &creator, &config);
+
+    // Remove factory from storage so buy_tickets skips the factory code path
+    env.as_contract(&contract_id, || {
+        env.storage().instance().remove(&DataKey::Factory);
+    });
+
+    // 3. Deposit prize and buy ticket
+    client.deposit_prize();
+    client.buy_tickets(&creator, &10);
+
+    // 4. Finalize raffle (requests randomness)
+    client.finalize_raffle();
+
+    // 5. Get request_id
+    let request_id: u64 = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&crate::DataKey::RandomnessRequestId)
+                .unwrap_or(0)
+        });
+
+    // 6. Try providing randomness immediately (should fail)
+    let (pk, sk) = env.crypto().ed25519_key_pair();
+    let seed = 123456789;
+    let message = seed.to_be_bytes();
+    let proof = env.crypto().ed25519_sign(&sk, &message);
+    let result = client.try_provide_randomness(&seed, &pk, &proof, &request_id);
+    assert_eq!(result.err(), Some(Ok(Error::RandomnessTooEarly)));
+}
+
+#[test]
+fn test_provide_randomness_succeeds_after_delay() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // 1. Setup factory, admin, creator
+    let factory = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let creator = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let payment_token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = StellarAssetClient::new(&env, &payment_token);
+    token_client.mint(&creator, &100_000_000);
+
+    let contract_id = env.register(Contract, ());
+    let client = ContractClient::new(&env, &contract_id);
+
+    // 2. Initialize Raffle with External Randomness
+    let config = RaffleConfig {
+        description: String::from_str(&env, "Test Raffle Delayed Randomness"),
+        end_time: 0,
+        no_deadline: true,
+        max_tickets: 10,
+        max_tickets_per_tx: 10,
+        min_tickets: 1,
+        allow_multiple: true,
+        ticket_price: 10_000,
+        payment_token: payment_token.clone(),
+        prize_amount: 10_000,
+        prizes: soroban_sdk::vec![&env, 10000],
+        randomness_source: RandomnessSource::External,
+        oracle_address: Some(oracle.clone()),
+        protocol_fee_bp: 0,
+        treasury_address: None,
+        swap_router: None,
+        tikka_token: None,
+        metadata_hash: BytesN::from_array(&env, &[1; 32]),
+        claim_lockup_seconds: 0,
+        swap_deadline_seconds: 0,
+    };
+
+    client.init(&factory, &admin, &creator, &config);
+
+    // Remove factory from storage so buy_tickets skips the factory code path
+    env.as_contract(&contract_id, || {
+        env.storage().instance().remove(&DataKey::Factory);
+    });
+
+    // 3. Deposit prize and buy ticket
+    client.deposit_prize();
+    client.buy_tickets(&creator, &10);
+
+    // 4. Finalize raffle (requests randomness)
+    client.finalize_raffle();
+
+    // 5. Simulate 10 ledgers passing
+    env.ledger().with_mut(|l| {
+        l.sequence_number += RANDOMNESS_MIN_DELAY_LEDGERS;
+        l.timestamp += 50; // 10 ledgers * 5 seconds
+    });
+
+    // 6. Get request_id
+    let request_id: u64 = env
+        .as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .get(&crate::DataKey::RandomnessRequestId)
+                .unwrap_or(0)
+        });
+
+    // 7. Provide randomness (should succeed)
+    let (pk, sk) = env.crypto().ed25519_key_pair();
+    let seed = 123456789;
+    let message = seed.to_be_bytes();
+    let proof = env.crypto().ed25519_sign(&sk, &message);
+    let result = client.provide_randomness(&seed, &pk, &proof, &request_id);
+    assert_eq!(result, contract_id);
+
+    // 8. Verify final state
+    let raffle_after = client.get_raffle();
+    assert_eq!(raffle_after.status, RaffleStatus::Finalized);
+}


### PR DESCRIPTION
## Description
This PR addresses a front-running vulnerability in the raffle contract's randomness fulfillment mechanism. Previously, an oracle could submit randomness immediately after a raffle transitioned to Drawing , creating a window for manipulation. We've implemented a 10-ledger minimum delay between randomness request and fulfillment.

## Changes Made
1. Added new error variant : Error::RandomnessTooEarly
2. Added delay constant : const RANDOMNESS_MIN_DELAY_LEDGERS: u32 = 10;
3. Updated provide_randomness : Added validation that 10+ ledgers have passed since request
4. Created SECURITY.md : Documented vulnerability, mitigation, and security considerations
5. Added comprehensive tests :
   - test_provide_randomness_fails_too_early : Verifies randomness submission fails before delay
   - test_provide_randomness_succeeds_after_delay : Verifies submission succeeds after 10 ledgers
## Impact
- No breaking changes to contract API
- Adds a critical security layer preventing immediate front-running
- Maintains all existing functionality
- All existing tests still pass
## Testing Instructions
The changes include two new tests that validate both failure and success scenarios for the new delay requirement.

Closes #413 