### PR TITLE
docs: create comprehensive commit-reveal protocol specifications and …

### DIFF
--- a/docs/COMMIT_REVEAL.md
+++ b/docs/COMMIT_REVEAL.md
@@ -1,0 +1,77 @@
+# Commit-Reveal Randomness Protocol
+
+This document explains the `RandomnessSource::CommitReveal` protocol, a multi-phase approach to generating fair, verifiable randomness for raffles.
+
+## 1. Protocol Steps
+
+The Commit-Reveal raffle lifecycle consists of four distinct phases:
+
+### 1.1 Raffle Creation
+The raffle creator initializes the raffle with `randomness_source = CommitReveal`.
+
+### 1.2 Commit Phase (Active State)
+During the raffle's Active state:
+- Each ticket buyer generates a local secret: `secret = random_bytes(32)`
+- The buyer computes a cryptographic hash: `hash = sha256(secret)`
+- The buyer calls `submit_commit(ticket_id, hash)` to commit their hash on-chain
+
+### 1.3 Draw Phase (finalize_raffle)
+When `finalize_raffle` is called:
+- The contract queries all existing `CommitEntry(ticket_id)` records
+- All collected hashes are concatenated and hashed sequentially: `combined = sha256(hash_1 || hash_2 || ... || hash_n)`
+- The first 8 bytes of the `combined` hash are extracted and used as the final draw seed
+
+### 1.4 Reveal Phase (Off-Chain, Optional)
+After the raffle finalizes, winners can reveal their original secret off-chain to mathematically prove the entropy generation was honest and unmanipulated.
+
+## 2. Ticket Transfer Invariant
+
+Commit entries are **structurally keyed by ticket ID**, not by the owner's public address. This means:
+- A commit submitted by the original buyer remains entirely intact and preserved even if the associated ticket is transferred or traded before finalization occurs
+- This prevents the silent loss of entropy when tickets change hands
+
+## 3. Fallback Behavior
+
+If zero commits are submitted by the time finalization is triggered, the contract automatically falls back to using an internal PRNG fallback mechanism so the raffle can still be finalized.
+
+## 4. Code Examples
+
+### TypeScript Example
+
+```typescript
+import crypto from 'crypto';
+
+function generateCommitHash(): { secret: Buffer; hash: Buffer } {
+  const secret = crypto.randomBytes(32);
+  const hash = crypto.createHash('sha256').update(secret).digest();
+  return { secret, hash };
+}
+
+// Usage
+const { secret, hash } = generateCommitHash();
+// Submit `hash` on-chain via submit_commit(ticket_id, hash)
+// Store `secret` securely for potential later reveal
+```
+
+### Rust Example
+
+```rust
+use sha2::{Sha256, Digest};
+use rand::RngCore;
+
+fn generate_commit_hash() -> (Vec<u8>, Vec<u8>) {
+    let mut secret = vec![0u8; 32];
+    rand::thread_rng().fill_bytes(&mut secret);
+    
+    let mut hasher = Sha256::new();
+    hasher.update(&secret);
+    let hash = hasher.finalize().to_vec();
+    
+    (secret, hash)
+}
+
+// Usage
+let (secret, hash) = generate_commit_hash();
+// Submit `hash` on-chain via submit_commit(ticket_id, hash)
+// Store `secret` securely for potential later reveal
+```


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for the RandomnessSource::CommitReveal protocol.

## Changes Made
- Created docs/COMMIT_REVEAL.md
## Documentation Content
The new file includes:

1. Protocol Steps : Explanation of all 4 phases (Raffle Creation, Commit Phase, Draw Phase, Reveal Phase)
2. Ticket Transfer Invariant : Documentation that commits are keyed by ticket ID, not owner address
3. Fallback Behavior : Explanation of the internal PRNG fallback when no commits are submitted
4. Code Examples : TypeScript and Rust code snippets for generating compatible commit hashes
## Purpose
This documentation helps contributors, frontend developers, and oracle integration teams understand the multi-step protocol, ticket invariance rules, fallback behavior, and implementation code patterns for the Commit-Reveal randomness path.


Closes #459 