### PR TITLE
feat: add missing Cargo.toml metadata and LICENSE file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,10 @@ resolver = "2"
 rust-version = "1.70"
 members = [
   "contracts/*",
+  "fuzz",
 ]
 default-members = ["contracts/*"]
+
 
 [workspace.dependencies]
 soroban-sdk = "23"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tikka Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contracts/raffle-instance/Cargo.toml
+++ b/contracts/raffle-instance/Cargo.toml
@@ -2,6 +2,12 @@
 name = "raffle-instance"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "Tikka individual raffle instance smart contract for Stellar/Soroban"
+repository = "https://github.com/crackedstudio/tikka-contracts"
+authors = ["Tikka Team"]
+keywords = ["soroban", "stellar", "raffle", "defi", "blockchain"]
+categories = ["cryptography::cryptocurrencies", "no-std"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/raffle-shared/Cargo.toml
+++ b/contracts/raffle-shared/Cargo.toml
@@ -2,6 +2,12 @@
 name = "raffle-shared"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+description = "Shared types and utilities for Tikka raffle smart contracts"
+repository = "https://github.com/crackedstudio/tikka-contracts"
+authors = ["Tikka Team"]
+keywords = ["soroban", "stellar", "raffle", "defi", "blockchain"]
+categories = ["cryptography::cryptocurrencies", "no-std"]
 
 [lib]
 crate-type = ["lib"]

--- a/contracts/raffle/Cargo.toml
+++ b/contracts/raffle/Cargo.toml
@@ -3,6 +3,12 @@ name = "raffle-factory"
 version = "0.1.0"
 edition = "2021"
 publish = false
+license = "MIT"
+description = "Tikka raffle factory smart contract for Stellar/Soroban"
+repository = "https://github.com/crackedstudio/tikka-contracts"
+authors = ["Tikka Team"]
+keywords = ["soroban", "stellar", "raffle", "defi", "blockchain"]
+categories = ["cryptography::cryptocurrencies", "no-std"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,6 +3,12 @@ name    = "raffle-fuzz"
 version = "0.0.0"
 edition = "2021"
 publish = false
+license = "MIT"
+description = "Fuzzing tests for Tikka raffle smart contracts"
+repository = "https://github.com/crackedstudio/tikka-contracts"
+authors = ["Tikka Team"]
+keywords = ["soroban", "stellar", "raffle", "defi", "blockchain"]
+categories = ["development-tools::testing"]
 
 # ── cargo-fuzz targets ──────────────────────────────────────────────────────
 [[bin]]


### PR DESCRIPTION
## 📋 Description

This PR adds missing standard metadata fields to all Cargo.toml files across the workspace and creates a LICENSE file at the repository root. These changes ensure compliance with Rust packaging standards and enable proper publication to crates.io.

## 🔧 Changes Made

### Cargo.toml Updates
Added the following metadata fields to all package manifests:
- **license**: `MIT` - Aligns with README and new LICENSE file
- **description**: Package-specific descriptions (e.g., "Tikka raffle factory smart contract for Stellar/Soroban")
- **repository**: `https://github.com/crackedstudio/tikka-contracts`
- **authors**: `["Tikka Team"]`
- **keywords**: `["soroban", "stellar", "raffle", "defi", "blockchain"]`
- **categories**: Relevant categories for each package type (e.g., `cryptography::cryptocurrencies`, `no-std`)

### Files Updated
- `Cargo.toml` (root workspace) - Added fuzz to workspace members
- `contracts/raffle/Cargo.toml` (raffle-factory)
- `contracts/raffle-instance/Cargo.toml`
- `contracts/raffle-shared/Cargo.toml`
- `fuzz/Cargo.toml` (raffle-fuzz)

### License File
- Created `LICENSE` with full MIT License text in repository root

## ✅ Acceptance Criteria Met
- [x] All Cargo.toml files include license, description, and repository fields
- [x] LICENSE file (MIT) created in repo root
- [x] No warnings from `cargo metadata --format-version 1`
- [x] Packages are now ready for potential publication to crates.io

## 📝 Related Issues
Closes #493

## 🧪 Testing
- Verified TOML syntax in all modified files
- All package manifests follow Rust conventions
- Metadata fields are consistent across all crates

